### PR TITLE
feat: install python build package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,4 @@
-######################################################################################################################################################
-
-# @project        Open Space Toolkit
-# @file           Makefile
-# @author         Lucas Brémond <lucas.bremond@gmail.com>
-# @license        Apache License 2.0
-
-######################################################################################################################################################
+# Apache License 2.0
 
 export project_name := open-space-toolkit-base
 export project_version := $(shell git describe --tags --always)
@@ -18,8 +11,6 @@ export docker_image_version := $(project_version)
 export jupyter_image := openspacecollective/open-space-toolkit-astrodynamics-jupyter:latest
 export jupyter_port := 8888
 
-######################################################################################################################################################
-
 build-image: ## Build image
 
 	docker build \
@@ -29,7 +20,7 @@ build-image: ## Build image
 		--build-arg="VERSION=$(docker_image_version)" \
 		"$(project_directory)/docker/development"
 
-######################################################################################################################################################
+.PHONY: build-image
 
 run-image: build-image ## Run image
 
@@ -39,9 +30,13 @@ run-image: build-image ## Run image
 		$(docker_image_repository):$(docker_image_version) \
 		/bin/bash
 
+.PHONY: run-image
+
 pull-jupyter: ## Pull jupyter image
 
 	docker pull $(jupyter_image)
+
+.PHONY: pull-jupyter
 
 run-jupyter: ## Run jupyter
 
@@ -51,27 +46,17 @@ run-jupyter: ## Run jupyter
 		--workdir=/notebooks \
 		$(jupyter_image)
 
-######################################################################################################################################################
+.PHONY: run-jupyter
 
 deploy-image: build-image ## Deploy image
 
 	docker push $(docker_image_repository):$(docker_image_version)
 	docker push $(docker_image_repository):latest
 
-######################################################################################################################################################
-
-.PHONY: build-image \
-		run-image \
-		pull-jupyter \
-		run-jupyter \
-		deploy-image
-
-######################################################################################################################################################
+.PHONY: deploy-image
 
 help:
 
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help
-
-################################################################################################################################################################

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,11 +1,4 @@
-################################################################################################################################################################
-
-# @project        Open Space Toolkit
-# @file           docker/development/Dockerfile
-# @author         Lucas Brémond <lucas.bremond@gmail.com>
-# @license        Apache License 2.0
-
-################################################################################################################################################################
+# Apache License 2.0
 
 FROM ubuntu:20.04
 
@@ -139,11 +132,11 @@ RUN python3.8 -m pip install --upgrade pip \
  && python3.9 -m pip install --upgrade pip \
  && python3.10 -m pip install --upgrade pip \
  && python3.11 -m pip install --upgrade pip \
- && python3 -m pip install --user --upgrade pip setuptools wheel twine pytest \
- && python3.8 -m pip install --user --upgrade setuptools wheel twine pytest \
- && python3.9 -m pip install --user --upgrade setuptools wheel twine pytest \
- && python3.10 -m pip install --user --upgrade setuptools wheel twine pytest \
- && python3.11 -m pip install --user --upgrade setuptools wheel twine pytest
+ && python3 -m pip install --user --upgrade pip setuptools build wheel twine pytest \
+ && python3.8 -m pip install --user --upgrade setuptools build wheel twine pytest \
+ && python3.9 -m pip install --user --upgrade setuptools build wheel twine pytest \
+ && python3.10 -m pip install --user --upgrade setuptools build wheel twine pytest \
+ && python3.11 -m pip install --user --upgrade setuptools build wheel twine pytest
 
 ## CMake
 
@@ -244,5 +237,3 @@ LABEL VERSION="${VERSION}"
 # Execution
 
 CMD ["/bin/bash"]
-
-################################################################################################################################################################

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,11 +1,4 @@
-################################################################################################################################################################
-
-# @project        Open Space Toolkit
-# @file           docker/jupyter/Dockerfile
-# @author         Lucas Brémond <lucas@loftorbital.com>
-# @license        Apache License 2.0
-
-################################################################################################################################################################
+# Apache License 2.0
 
 ARG JUPYTER_NOTEBOOK_IMAGE_REPOSITORY=jupyter/scipy-notebook:latest
 
@@ -39,8 +32,8 @@ COPY ./shortcuts-extension /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/s
 
 RUN chown -R ${NB_UID}:${NB_UID} /home/jovyan/.jupyter
 
-ENV LD_LIBRARY_PATH "/usr/local/lib:/usr/lib/x86_64-linux-gnu:/opt/conda/lib/python3.8/site-packages:/home/jovyan/lib:/opt/conda/lib"
-ENV PYTHONPATH "/opt/conda/lib/python3.8/site-packages:/home/jovyan/lib"
+ENV LD_LIBRARY_PATH "/usr/local/lib:/usr/lib/x86_64-linux-gnu:/opt/conda/lib/python3.10/site-packages:/home/jovyan/lib:/opt/conda/lib"
+ENV PYTHONPATH "/opt/conda/lib/python3.10/site-packages:/home/jovyan/lib"
 
 # Install Open Space Toolkit
 
@@ -53,5 +46,3 @@ USER ${NB_UID}
 # Disable token
 
 CMD ["start-notebook.sh", "--NotebookApp.token=''"]
-
-################################################################################################################################################################


### PR DESCRIPTION
- Need `pypa/build` for all python versions in order to use `python -m build` command to follow [PEP517](https://peps.python.org/pep-0517/) in python bindings package distributions build (replacing `setup.py` with `pyproject.toml` and `setup.cfg`. 