### PR TITLE
fix: gitter to discord in contribution guide and typos in an NB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This project and everyone participating in it is governed by our [Code of Conduc
 ## I Have a Question!
 
 Please don't file an issue to ask a question.
-You'll get faster results by reaching out on our [Gitter](https://gitter.im/open-space-collective/community).
+You'll get faster results by reaching out on our [Discord](https://discord.gg/tuHRnjuzWS).
 
 ## How Can I Contribute?
 

--- a/notebooks/Astrodynamics/Orbit Computation/Lagrange Points Computation CR3BP.ipynb
+++ b/notebooks/Astrodynamics/Orbit Computation/Lagrange Points Computation CR3BP.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial illustrated the computation of the five lagrange points (equilibrium solutions) of the **Earth-Moon** system modeled through the Circular Restricted Three Body Problem (CR3BP).\n",
+    "This tutorial illustrates the computation of the five lagrange points (equilibrium solutions) of the **Earth-Moon** system modeled through the Circular Restricted Three Body Problem (CR3BP).\n",
     "\n",
     "The location of the points are computed with respect to the barycenter of the primiaries in a rotating reference frame."
    ]
@@ -111,7 +111,7 @@
     "# Define a common frame\n",
     "frame = Frame.ITRF()\n",
     "\n",
-    "def get_EM_dist_at_epoch(p1, p2, day):\n",
+    "def get_p1p2_dist_at_epoch(p1, p2, day):\n",
     "\n",
     "    instant = Instant.J2000() + Duration.days(float(day))\n",
     "\n",
@@ -124,7 +124,7 @@
     "    return distance\n",
     "\n",
     "# Distances over a lunar cycle\n",
-    "distances = [get_EM_dist_at_epoch(p1, p2, day) for day in range(28)]\n",
+    "distances = [get_p1p2_dist_at_epoch(p1, p2, day) for day in range(28)]\n",
     "\n",
     "# Average distance in km\n",
     "lstar = np.average(np.array(distances)/1000.0)\n",
@@ -152,7 +152,7 @@
      "output_type": "stream",
      "text": [
       "P1 location wrt barycenter: [-4682.7551241231859 0.0 0.0] km\n",
-      "P1 location wrt barycenter: [380710.66735577409 0.0 0.0] km\n"
+      "P2 location wrt barycenter: [380710.66735577409 0.0 0.0] km\n"
      ]
     }
    ],
@@ -188,7 +188,7 @@
    "metadata": {},
    "source": [
     "### Computation of collinear Lagrange points (L<sub>1</sub>, L<sub>2</sub> and L<sub>3</sub>)\n",
-    "Collinear Lagrange points are the equlibrium solutions of CR3BP EOMS with y=z=0, and are computed through the roots of the polynmial derived using "
+    "Collinear Lagrange points are the equlibrium solutions of CR3BP EOMS that are computed through the roots of the polynmial derived by subsituting, $y=z=\\dot{x}=\\dot{y}=\\dot{z}=\\ddot{x}=\\ddot{y}=\\ddot{z}=0$, to the EOMs. "
    ]
   },
   {


### PR DESCRIPTION
- Update the contribution guide with the Discord link in place of Gitter. 
- Fix typos in the Lagrange point computation notebook.