### PR TITLE
chore: tar/untar documentation files to preserve casing

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -224,10 +224,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Documentation
         run: make build-documentation-standalone
+      - name: Tar files
+        run: tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
         uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: docs/
+          path: docs.tar.gz
 
 ################################################################################################################################################################

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docs
-          path: docs/
+          path: docs.tar.gz
+      - name: Untar Files
+        run: tar -xvf docs.tar.gz && rm docs.tar.gz
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
https://github.com/seemethere/upload-artifact-s3?tab=readme-ov-file#case-insensitive-uploads
Due to this the documentation in the astro repo has some dead links. To fix this it is recommended to tar files before upload.

