### PR TITLE
chore: refactor build workflow to be more modular

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
-################################################################################################################################################################
+# Apache License 2.0
 
-# @project        Open Space Toolkit
-# @file           .github/workflows/build-test.yml
-# @author         Lucas Brémond <lucas@loftorbital.com>
-# @license        Apache License 2.0
-
-################################################################################################################################################################
-
-name: Build and Test
+name: Build
 
 on:
   workflow_call:


### PR DESCRIPTION
This MR is intended to reduce the coupling between the build and test workflows in the build-test.yml file, so that downstream workflows in the other OSTk repos can build the docker image with this workflow but run their tests seperately