### PR TITLE
chore: update ostk-build to default to debug mode build

### DIFF
--- a/tools/development/helpers/build.sh
+++ b/tools/development/helpers/build.sh
@@ -9,13 +9,13 @@ mkdir -p "${build_directory}"
 
 pushd "${build_directory}" > /dev/null
 
-if [[ ! -z $1 ]] && [[ $1 == "--debug" ]]; then
+if [[ ! -z $1 ]] && [[ $1 == "--release" ]]; then
 
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DCMAKE_BUILD_TYPE=Release ..
 
 else
 
-    cmake ..
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 fi
 


### PR DESCRIPTION
Updates `ostk-build` to default to debug mode building instead of release mode building, because compilation times are much faster that way and debug mode tests are what is run in the CI. So if you're going to build one or the other, it should be debug mode instead of release mode.

you can still use the --release flag to build in release mode after `ostk-build`