### PR TITLE
build: add CESIUM_TOKEN env var to build-packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -109,6 +109,8 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+      - env:
+          CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Adding a CESIUM_TOKEN here that will be used by the Jupyter notebooks when rendering the tutorials, which will allow us to have an embedded Cesium viewer in the tutorials!