### PR TITLE
build: remove base image multi-stage build

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -43,29 +43,16 @@ jobs:
           echo "Project version: ${project_version}"
           echo "value=${project_version}" >> $GITHUB_OUTPUT
 
-  build-part1-of-base-image:
-    name: Build Part 1 of Base Image
+  build-and-push-and-tag-base-image:
+    name: Build and Push and Tag Base Image with Version
     needs:
       - prepare-environment
-    uses: ./.github/workflows/build-image.yml
-    with:
-      project_name: ${{ needs.prepare-environment.outputs.project_name }}
-      project_version: ${{ needs.prepare-environment.outputs.project_version }}
-      push: false
-      target: base1
-    secrets: inherit
-
-  build-part2-and-push-and-tag-base-image:
-    name: Build Part 2 and Push and Tag Base Image with Version
-    needs:
-      - prepare-environment
-      - build-part1-of-base-image
     uses: ./.github/workflows/build-image.yml
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}
       push: true
-      target: base2
+      target: base
     secrets: inherit
 
   push-and-tag-base-image-as-latest:
@@ -73,11 +60,11 @@ jobs:
     name: Push and Tag Base Image as Latest
     needs:
       - prepare-environment
-      - build-part2-and-push-and-tag-base-image
+      - build-and-push-and-tag-base-image
     uses: ./.github/workflows/build-image.yml
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: latest
       push: true
-      target: base2
+      target: base
     secrets: inherit

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-FROM ubuntu:20.04 as base1
+FROM ubuntu:20.04 as base
 
 LABEL maintainer="lucas.bremond@gmail.com"
 
@@ -93,8 +93,6 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 && \
    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \
    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
-
-FROM base1 as base2
 
 ## Python tools
 


### PR DESCRIPTION
Now that the build process is much shorter (because we are no longer building python from source), we can build the base image in one stage because it no longer exceeds the 6 hour CI build limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined GitHub Actions workflow for base image build process
	- Simplified Docker base image stage naming
	- Consolidated build and push operations into a single job

<!-- end of auto-generated comment: release notes by coderabbit.ai -->