### PR TITLE
build: remove apt-installed numpy

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -103,7 +103,6 @@ FROM base1 as base2
 RUN apt-get update -y \
    && apt-get install -y --no-install-recommends \
    python3-dev \
-   python3-numpy \
    python3-pip \
    && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Removes the `apt`-installed version of numpy from the dev image, as it causes pybind11-stubgen to throw the following error (for all python versions):
<details>
<summary>Traceback</summary>

```
  File "/usr/local/lib/python3.9/dist-packages/pybind11_stubgen/parser/mixins/fix.py", line 186, in _is_module
    return importlib.import_module(str(name)) is not None
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3/dist-packages/numpy/__init__.py", line 142, in <module>
    from . import core
  File "/usr/lib/python3/dist-packages/numpy/core/__init__.py", line 47, in <module>
    raise ImportError(msg)
ImportError: 

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy c-extensions failed.
- Try uninstalling and reinstalling numpy.
- If you have already done that, then:
  1. Check that you expected to use Python3.9 from "/usr/bin/python3.9",
     and that you have no directories in your PATH or PYTHONPATH that can
     interfere with the Python and numpy version "1.17.4" you're trying to use.
  2. If (1) looks fine, you can open a new issue at
     https://github.com/numpy/numpy/issues.  Please include details on:
     - how you installed Python
     - how you installed numpy
     - your operating system
     - whether or not you have multiple versions of Python installed
     - if you built from source, your compiler versions and ideally a build log

- If you're working with a numpy git repository, try `git clean -xdf`
  (removes all files not under version control) and rebuild numpy.

Note: this error has many possible causes, so please don't comment on
an existing issue about this - open a new one instead.

Original error was: No module named 'numpy.core._multiarray_umath'
```
</details> 

This also slightly reduces bloat in the dev container for ostk-io and ostk-core, as they don't require numpy at all. 

This shouldn't be a breaking change as `ostk-maths` [explicitly has numpy as a requirement](https://github.com/open-space-collective/open-space-toolkit-mathematics/blob/main/bindings/python/requirements.txt#L3); however, pip skipped installing this because it saw the system-wide numpy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development Dockerfile configuration
	- Removed `python3-numpy` package from the development environment
	- Maintained multi-Python version support (3.8-3.13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->