### PR TITLE
build: update artifact actions to v4

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           name: cpp-package
           path: packages/cpp/
-          overwrite: true
 
   build-package-python:
     name: Build Python Package
@@ -100,7 +99,6 @@ jobs:
         with:
           name: python-package
           path: packages/python/
-          overwrite: true
 
   build-documentation:
     name: Build Documentation
@@ -127,4 +125,3 @@ jobs:
         with:
           name: docs
           path: docs.tar.gz
-          overwrite: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -57,10 +57,11 @@ jobs:
         run: make build-packages-cpp-standalone TARGETPLATFORM=${{ matrix.architecture }}
       - name: Upload C++ Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp-package
           path: packages/cpp/
+          overwrite: true
 
   build-package-python:
     name: Build Python Package
@@ -95,10 +96,11 @@ jobs:
         run: make build-packages-python-standalone TARGETPLATFORM=${{ matrix.architecture }}
       - name: Upload Python Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package
           path: packages/python/
+          overwrite: true
 
   build-documentation:
     name: Build Documentation
@@ -121,7 +123,8 @@ jobs:
       - name: Tar files
         run: tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs.tar.gz
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Download C++ Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cpp-package
           path: packages/cpp/
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Download Python Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package
           path: packages/python/
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Download Documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs
       - name: Untar Files


### PR DESCRIPTION
Bumps the upload-artifact action to v4, following the [deprecation of v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). The [breaking changes](https://github.com/actions/upload-artifact/blob/v4.5.0/docs/MIGRATION.md) shouldn't affect us, notably:
- None of the artifacts should contain hidden files
- Since artifacts are scoped per workflow invocation, we don't need to worry about them now becoming immutable; see [run 1](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12687740826/attempts/1), and a [re-run](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12687740826/attempts/2) of the same workflow attempt both succeeding. 

Symmetrically, [download-artifact](https://github.com/actions/download-artifact/tree/v4.1.8?tab=readme-ov-file#actionsdownload-artifact) should also be bumped to v4. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow files to use the latest versions of `actions/upload-artifact` and `actions/download-artifact` actions (v4)
	- Maintained existing workflow logic and structure while upgrading action versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->