### PR TITLE
fix: upload artefacts with different names

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -59,7 +59,7 @@ jobs:
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v4
         with:
-          name: cpp-package
+          name: cpp-package-${{ matrix.architecture }}
           path: packages/cpp/
 
   build-package-python:
@@ -97,7 +97,7 @@ jobs:
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v4
         with:
-          name: python-package
+          name: python-package-${{ matrix.architecture }}
           path: packages/python/
 
   build-documentation:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Download C++ Package
         uses: actions/download-artifact@v4
         with:
-          name: cpp-package
+          pattern: cpp-package-*
+          merge-multiple: true
           path: packages/cpp/
       - name: Release C++ Package
         uses: softprops/action-gh-release@v1
@@ -63,7 +64,8 @@ jobs:
       - name: Download Python Package
         uses: actions/download-artifact@v4
         with:
-          name: python-package
+          pattern: python-package-*
+          merge-multiple: true
           path: packages/python/
       - name: Deploy Python Package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
[Downstream repo pipelines are failing](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12700583041/job/35403671170) because multiple artefacts (for different architectures) are being written to the same name. 

In v4 of the upload/download actions, [this is no longer allowed](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12700583041/job/35403671170), so I'm applying their recommended migration plan here. 

Missed this because I only tested the upload/download artefacts migration in a PR, but these steps only trigger on merge & release. 