### PR TITLE
build: parallelize python pip installation and remove redudant python-pip install

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -98,8 +98,8 @@ RUN curl -sSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
 
 ## Python tools
 
-RUN parallel -j$(nproc) "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13 && \
-    parallel -j$(nproc) "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
+RUN parallel -j$(nproc) "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13
+RUN parallel -j$(nproc) "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
 
 ## CMake
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update -y \
    tree \
    make \
    libssl-dev \
-   parallel \
    && rm -rf /var/lib/apt/lists/*
 
 # Development Tools
@@ -88,19 +87,25 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
    python3.12 python3.12-dev \
    python3.13 python3.13-dev \
    python3-dev \
-   python3-pip \
    && rm -rf /var/lib/apt/lists/*
 
 ## Pip
 
-RUN curl -sSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-   parallel "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
-   rm /tmp/get-pip.py
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 \
+   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
+   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 \
+   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
+   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13 \
+   & wait
 
 ## Python tools
 
-RUN parallel "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13
-RUN parallel "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
+RUN python3.9 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   & python3.10 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   & python3.11 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   & python3.12 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   & python3.13 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   & wait
 
 ## CMake
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -93,13 +93,13 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 ## Pip
 
 RUN curl -sSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-   parallel -j5 "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
+   parallel -j$(nproc) "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
    rm /tmp/get-pip.py
 
 ## Python tools
 
-RUN parallel -j5 "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13 && \
-    parallel -j5 "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
+RUN parallel -j$(nproc) "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13 && \
+    parallel -j$(nproc) "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
 
 ## CMake
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y \
    tree \
    make \
    libssl-dev \
+   parallel \
    && rm -rf /var/lib/apt/lists/*
 
 # Development Tools
@@ -79,39 +80,26 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 
 ## Python
 
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get update && apt-get install -y \
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+   apt-get update && apt-get install -y --no-install-recommends \
    python3.9 python3.9-distutils python3.9-dev \
    python3.10 python3.10-distutils python3.10-dev \
    python3.11 python3.11-distutils python3.11-dev \
    python3.12 python3.12-dev \
-   python3.13 python3.13-dev
+   python3.13 python3.13-dev \
+   python3-dev \
+   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
-   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
-   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 && \
-   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \
-   curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
+## Pip
+
+RUN curl -sSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+   parallel -j5 "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
+   rm /tmp/get-pip.py
 
 ## Python tools
 
-RUN apt-get update -y \
-   && apt-get install -y --no-install-recommends \
-   python3-dev \
-   python3-pip \
-   && rm -rf /var/lib/apt/lists/*
-
-RUN python3.9 -m pip install --upgrade pip ipython \
-   && python3.10 -m pip install --upgrade pip ipython \
-   && python3.11 -m pip install --upgrade pip ipython \
-   && python3.12 -m pip install --upgrade pip ipython \
-   && python3.13 -m pip install --upgrade pip ipython \
-   && python3.9 -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.10 -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.11 -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.12 -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.13 -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen
+RUN parallel -j5 "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13 && \
+    parallel -j5 "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
 
 ## CMake
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -88,18 +88,19 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
    python3.12 python3.12-dev \
    python3.13 python3.13-dev \
    python3-dev \
+   python3-pip \
    && rm -rf /var/lib/apt/lists/*
 
 ## Pip
 
 RUN curl -sSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-   parallel -j$(nproc) "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
+   parallel "python{} /tmp/get-pip.py" ::: 3.9 3.10 3.11 3.12 3.13 && \
    rm /tmp/get-pip.py
 
 ## Python tools
 
-RUN parallel -j$(nproc) "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13
-RUN parallel -j$(nproc) "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
+RUN parallel "python{} -m pip install --upgrade pip ipython" ::: 3.9 3.10 3.11 3.12 3.13
+RUN parallel "python{} -m pip install --upgrade setuptools build wheel twine pytest pybind11-stubgen" ::: 3.9 3.10 3.11 3.12 3.13
 
 ## CMake
 


### PR DESCRIPTION
This PR hopes to speed up the main dockerfile build a little more to get more margin under the 6h github runner limit.

It does this by removing unneeded python installations and parallelizing the pip installing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Optimized Docker build process by introducing parallel package installation.
	- Streamlined Python package installation across multiple Python versions.
	- Added Python development headers to the build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->