### PR TITLE
chore: fix dockerfile warnings

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-FROM ubuntu:20.04 as base
+FROM ubuntu:20.04 AS base
 
 LABEL maintainer="lucas.bremond@gmail.com"
 
@@ -187,14 +187,14 @@ RUN mkdir /tmp/openssl \
 ## Black
 
 ARG OSTK_PYTHON_VERSION
-ENV OSTK_PYTHON_VERSION 3.11
+ENV OSTK_PYTHON_VERSION="3.11"
 
 RUN python${OSTK_PYTHON_VERSION} -m pip install black black[jupyter]
 
 # Environment
 
-ENV LD_LIBRARY_PATH /usr/local/lib:${LD_LIBRARY_PATH}
-ENV PYTHONPATH /usr/local/lib:${PYTHONPATH}
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV PYTHONPATH="/usr/local/lib:${PYTHONPATH}"
 RUN git config --global --add safe.directory /app
 
 # Install development helpers
@@ -229,7 +229,7 @@ RUN chmod +x /usr/bin/ostk-build \
 
 ARG VERSION
 
-ENV VERSION ${VERSION}
+ENV VERSION="${VERSION}"
 
 LABEL VERSION="${VERSION}"
 

--- a/docker/jupyter-web/Dockerfile
+++ b/docker/jupyter-web/Dockerfile
@@ -8,7 +8,7 @@ FROM ${JUPYTER_NOTEBOOK_IMAGE_REPOSITORY}
 
 LABEL maintainer="kyle.cochran@loftorbital.com"
 
-ENV JUPYTER_ENABLE_LAB yes
+ENV JUPYTER_ENABLE_LAB="yes"
 
 # Set user to root
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -6,7 +6,7 @@ FROM ${JUPYTER_NOTEBOOK_IMAGE_REPOSITORY}
 
 LABEL maintainer="lucas@loftorbital.com"
 
-ENV JUPYTER_ENABLE_LAB yes
+ENV JUPYTER_ENABLE_LAB="yes"
 
 # Set user to root
 


### PR DESCRIPTION
So that github finally stops yelling at me:
![image](https://github.com/user-attachments/assets/e54fe07c-bde4-45b5-86e9-32483ab4ba87)

Changes:
- `as` -> `AS`
- `ENV key value` -> `ENV key="value"`
    - All environment variables are strings anyway, so this should be safe. This also avoids the "Usage of undefined variable" warning.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated Docker environment variable declarations to use consistent quote formatting across multiple Dockerfiles
	- Modified `FROM` instruction syntax in development Dockerfile to use uppercase `AS`

- **Chores**
	- Standardized environment variable declarations in development and Jupyter Docker configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->