### PR TITLE
fix: remove slashes in artifact names

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -67,7 +67,7 @@ jobs:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
-          name: cpp-package-$ARTIFACT_NAME
+          name: cpp-package-${{ env.ARTIFACT_NAME }}
           path: packages/cpp/
 
   build-package-python:
@@ -113,7 +113,7 @@ jobs:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-$ARTIFACT_NAME
+          name: python-package-${{ env.ARTIFACT_NAME }}
           path: packages/python/
 
   build-documentation:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -55,11 +55,19 @@ jobs:
       - name: Build C++ Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: make build-packages-cpp-standalone TARGETPLATFORM=${{ matrix.architecture }}
+      - name: Format artifact name
+        id: format-artifact-name
+        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: |
+          artifact_name=$(echo "${{ matrix.architecture }}" | tr / -)
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload C++ Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        env:
+          ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
-          name: cpp-package-${{ matrix.architecture }}
+          name: cpp-package-$ARTIFACT_NAME
           path: packages/cpp/
 
   build-package-python:
@@ -93,11 +101,19 @@ jobs:
       - name: Build Python Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: make build-packages-python-standalone TARGETPLATFORM=${{ matrix.architecture }}
+      - name: Format artifact name
+        id: format-artifact-name
+        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: |
+          artifact_name=$(echo "${{ matrix.architecture }}" | tr / -)
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload Python Package
         if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        env:
+          ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-${{ matrix.architecture }}
+          name: python-package-$ARTIFACT_NAME
           path: packages/python/
 
   build-documentation:


### PR DESCRIPTION
🤦 
[This fix](https://github.com/open-space-collective/open-space-toolkit/pull/148) didn't work because it tried to create artifacts named like `cpp-package-linux/amd64`, which isn't allowed. This change instead names them like `cpp-package-linux-amd64`. Unfortunately there's no built-in function in the github workflows syntax to replace a character, so I've had to add another small step to the job to replace it in bash. 

See [failed job](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12751972998/job/35540539139) vs[ successful job](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12752646923).

The [release job](https://github.com/open-space-collective/open-space-toolkit/pull/148/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R46) now pulls using a wildcard `-*`, so it _should_ still work. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to improve artifact naming flexibility.
	- Enhanced package build process with dynamic artifact name generation based on architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->