### PR TITLE
chore: remove unnecessary path append

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -193,8 +193,8 @@ RUN python${OSTK_PYTHON_VERSION} -m pip install black black[jupyter]
 
 # Environment
 
-ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
-ENV PYTHONPATH="/usr/local/lib:${PYTHONPATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+ENV PYTHONPATH="/usr/local/lib"
 RUN git config --global --add safe.directory /app
 
 # Install development helpers


### PR DESCRIPTION
Turns out the "undefined variable" warnings that the Docker linter was throwing out WEREN'T false positives: I had assumed we were appending to pre-existing `PYTHONPATH` and `LD_LIBRARY_PATH` variables, but they are indeed unset: 
![image](https://github.com/user-attachments/assets/39bdecfa-bed4-4987-9f4a-15685888bdbd)

This PR removes the empty variables and correctly addresses the warnings: https://github.com/open-space-collective/open-space-toolkit/actions/runs/12765578228

This also means [this PR's claimed fix](https://github.com/open-space-collective/open-space-toolkit/pull/150) is incorrect - see the warnings [here](https://github.com/open-space-collective/open-space-toolkit/actions/runs/12754814368). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker development environment configuration
	- Simplified Python tool installation process
	- Refined environment variable settings for library and module paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->