### PR TITLE
build: install cmake from binary instead of source

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -61,6 +61,7 @@ jobs:
           build-args: |
             BASE_IMAGE_SYSTEM=debian
             VERSION=${{ inputs.project_version }}
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ inputs.target }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -61,7 +61,6 @@ jobs:
           build-args: |
             BASE_IMAGE_SYSTEM=debian
             VERSION=${{ inputs.project_version }}
-          cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ inputs.target }}
           platforms: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ export docker_image_version := $(project_version)
 export jupyter_image := openspacecollective/open-space-toolkit-astrodynamics-jupyter:latest
 export jupyter_port := 8888
 
+
+# Handle multi-platform builds locally (CI sets these env vars, but need defaults here)
+TARGETPLATFORM ?= linux/amd64
+$(info Target platform is $(TARGETPLATFORM))
+
+
 build-image: ## Build image
 
 	docker build \

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -109,19 +109,19 @@ RUN python3.9 -m pip install --upgrade pip ipython setuptools build wheel twine 
 
 ## CMake
 
+ARG TARGETPLATFORM
 ARG CMAKE_MAJOR_VERSION="3"
 ARG CMAKE_MINOR_VERSION="26"
 ARG CMAKE_PATCH_VERSION="3"
 ARG CMAKE_VERSION="${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}"
 
-RUN cd /tmp \
-   && wget --quiet https://cmake.org/files/v${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
-   && tar -xf cmake-${CMAKE_VERSION}.tar.gz \
-   && cd cmake-${CMAKE_VERSION} \
-   && ./bootstrap \
-   && make -j $(nproc) \
-   && make install \
-   && rm -rf /tmp/cmake-${CMAKE_VERSION} /tmp/cmake-${CMAKE_VERSION}.tar.gz
+RUN mkdir -p /tmp/cmake \
+   && cd /tmp/cmake \
+   && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+   && wget --quiet https://cmake.org/files/v${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/cmake-${CMAKE_VERSION}-linux-${PACKAGE_PLATFORM}.sh -O cmake-install.sh \
+   && chmod +x /tmp/cmake/cmake-install.sh \
+   && /tmp/cmake/cmake-install.sh --prefix=/usr/local --skip-license \
+   && rm -rf /tmp/cmake
 
 ## GoogleTest
 


### PR DESCRIPTION
This MR changes the dockerfile to install cmake from a pre-built binary using the self install shell script (which was excruciatingly slow before) for the specifc platform. This should help get the build time way below the 6h GH actions limit.

I checked that this works locally and results in the `bin` and `share` and other directories that comes with cmake when it is built from source are all installed in the correct place under `/usr/local`
Here's an example of someone else doing pretty much the same install from pre-built binary (except they just install it in the /opt dir and symlink it whereas we directly install it in the correct place with the --prefix option)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for multi-platform builds across build configuration files
	- Enhanced Docker build process to handle different target platforms

- **Chores**
	- Updated GitHub Actions workflow build configuration
	- Simplified CMake installation process in development Dockerfile

- **Infrastructure**
	- Introduced `TARGETPLATFORM` variable to support cross-platform compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->