### PR TITLE
fix: re-add clang symlink

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -58,17 +58,18 @@ RUN apt-get update -y \
    gnupg \
    && rm -rf /var/lib/apt/lists/*
 
-## Clang-format
+## Clang-format & Clang
 
-ARG CLANG_FORMAT_VERSION="18"
+ARG CLANG_VERSION="18"
 
-RUN mkdir -p /tmp/clang-format \
-   && cd /tmp/clang-format \
+RUN mkdir -p /tmp/clang \
+   && cd /tmp/clang \
    && wget https://apt.llvm.org/llvm.sh \
    && chmod +x llvm.sh \
-   && ./llvm.sh ${CLANG_FORMAT_VERSION} all \
-   && rm -rf /tmp/clang-format \
-   && ln -s /usr/bin/clang-format-${CLANG_FORMAT_VERSION} /usr/bin/clang-format
+   && ./llvm.sh ${CLANG_VERSION} all \
+   && rm -rf /tmp/clang \
+   && ln -s /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format \
+   && ln -s /usr/bin/clang-${CLANG_VERSION} /usr/bin/clang
 
 ## GCC / G++
 


### PR DESCRIPTION
When we updated the way we install `clang-format` in [this PR](https://github.com/open-space-collective/open-space-toolkit/pull/169), we inadvertently deleted a symlink to `clang` in the base image (we manually create the symlink for `clang-format` in the Dockerfile).

This broke downstream ARM64 builds in ostk-physics, because SPICEToolkit expects there to be an executable named `clang` in the PATH. See [this downstream issue](https://github.com/open-space-collective/open-space-toolkit-physics/issues/328) for more details. 

This PR manually creates the `clang` symlink like we do for `clang-format`, and also renames some variables to be more explicit that we actually require both `clang` and `clang-format`. (strictly speaking, this still doesn't accurately reflect what we're doing in this step because we actually install the entire LLVM toolchain, but I think that could potentially be more misleading). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the Clang tools installation process in the development environment with updated naming conventions and streamlined directory management for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->