### PR TITLE
fix: remove parallel pip install

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -104,11 +104,10 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 \
 ## Python tools
 
 RUN python3.9 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   & python3.10 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   & python3.11 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   & python3.12 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   & python3.13 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   & wait
+   && python3.10 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   && python3.11 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   && python3.12 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
+   && python3.13 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen
 
 ## CMake
 


### PR DESCRIPTION
Installing pip dependencies in parallel introduces a race condition that can cause the package installations to fail silently for **some** Python versions. 

In particular, `urllib3` is required by `twine`, and `Pygments` is required by `ipython`. However, both `urllib3` and `Pygments` are already installed in `/usr/lib/python3/dist-packages/`, which on Debian-based systems, is the destination when installing a package using `apt` (NOT `pip`): 
![image](https://github.com/user-attachments/assets/87099378-89c6-4be9-8257-dce8fb75a91b)

When we subsequently run `python3.9 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen`, `pip` will attempt to uninstall the "system" `twine` and `Pygments`, and instead install them in the "local" and Python-version-dependent `usr/local/lib/python3.9/dist-packages/`:
![image](https://github.com/user-attachments/assets/266c7268-1142-49e6-8dbb-e809ec307be8)
![image](https://github.com/user-attachments/assets/6fd3f906-bebc-49df-9217-6174b0d76f5f)

When we run multiple sets of this commands in parallel (for each Python version), each `pip` will try to delete the 
**same** "system" `urllib3` and `Pygments`. 

At best, this can throw some warnings like this: 
![image](https://github.com/user-attachments/assets/0594e324-1265-4537-871d-a43ea40bc9fd)

At worst, it can cause the entire `pip install` command to fail: 
![image](https://github.com/user-attachments/assets/27908ac5-c265-4cd2-9d6b-3fbb148175fd)

Furthermore, I think `wait` only returns the exit code of the _last_ background process to finish, so we will not catch these exceptions most of the time. 

This phenomena occurred in the [release pipeline](https://github.com/open-space-collective/open-space-toolkit/actions/runs/13501793080/job/37721814902#step:6:2713) for version `0.10.1`, so the development image is actually missing dependencies for some Python versions. 

Installing these dependencies isn't too slow to run in series, because the `pip` cache will be populated after the first install command, and so the subsequent installs will be much faster and always hit the cache. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the environment setup process for Python dependencies by ensuring each installation step completes successfully before the next begins. This improvement minimizes the risk of setup errors and contributes to greater overall stability during the initialization process, leading to a more reliable end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->