### PR TITLE
ci: use dedicated ARM runners

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   benchmark-cpp:
     name: Benchmark C++
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-benchmark
       - uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: 'googlecpp'
+          tool: "googlecpp"
           output-file-path: bin/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.ref == 'refs/heads/main' }}
@@ -58,7 +58,7 @@ jobs:
 
   validation-cpp:
     name: Run C++ Validation Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -10,7 +10,6 @@ on:
   release:
     types: [published]
 
-
 concurrency:
   group: main-${{ github.ref }}
   cancel-in-progress: true
@@ -21,7 +20,7 @@ env:
 jobs:
   prepare-environment:
     name: Prepare Environment Variables
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       project_name: ${{ steps.project-name.outputs.value }}
       project_version: ${{ steps.project-version.outputs.value }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Prepare Artifact Path
         run: |
           platform=${{ matrix.architecture.platform }}
-          echo "PLATFORM_PATH=${platform//\//-} >> $GITHUB_ENV"
+          echo "PLATFORM_PATH=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Upload Digest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,10 +40,9 @@ jobs:
       matrix:
         architecture:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-
     runs-on: ${{ matrix.architecture.runner }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
+  IMAGE_TAG: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
   LANG: en_US.UTF-8
 
 jobs:
@@ -58,9 +59,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Development Image
+        id: build
         uses: docker/build-push-action@v6
         with:
-          tags: ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+          tags: ${{ env.IMAGE_TAG }}
           context: .
           file: ./docker/development/Dockerfile
           build-args: |
@@ -71,3 +73,45 @@ jobs:
           target: ${{ inputs.target }}
           platforms: ${{ matrix.architecture.platform }}
           push: ${{ inputs.push }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
+
+      - name: Export Digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload Digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.architecture.platform }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs:
+      - build-image-development
+    steps:
+      - name: Download Digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: disgests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create Manifest List and Push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create -t ${{ env.IMAGE_TAG }} \
+            $(printf '${{ env.IMAGE_TAG }}@sha256:%s ' *)

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -82,10 +82,15 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
+      - name: Prepare Artifact Path
+        run: |
+          platform=${{ matrix.architecture.platform }}
+          echo "PLATFORM_PATH=${platform//\//-} >> $GITHUB_ENV"
+
       - name: Upload Digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.architecture.platform }}
+          name: digests-${{ env.PLATFORM_PATH }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -95,7 +95,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  merge-manifests:
+    name: Merge Image Manifests
     runs-on: ubuntu-24.04
     needs:
       - build-image-development

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -36,17 +36,21 @@ env:
 jobs:
   build-image-development:
     name: Build Development Image
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.architecture.runner }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v8.1.5 # https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2611042596
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
@@ -66,5 +70,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ inputs.target }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.architecture.platform }}
           push: ${{ inputs.push }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
+  IMAGE_NAME: openspacecollective/${{ inputs.project_name }}-development
   IMAGE_TAG: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
   LANG: en_US.UTF-8
 
@@ -62,7 +63,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          tags: ${{ env.IMAGE_TAG }}
+          tags: ${{ env.IMAGE_NAME }}
           context: .
           file: ./docker/development/Dockerfile
           build-args: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -121,4 +121,4 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_TAG }} \
-            $(printf '${{ env.IMAGE_TAG }}@sha256:%s ' *)
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: disgests-*
+          pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -116,7 +116,7 @@ jobs:
 
   build-documentation:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -26,44 +26,42 @@ env:
 jobs:
   build-package-cpp:
     name: Build C++ Package
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        architecture: [linux/amd64, linux/arm64]
+        architecture:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.architecture.runner }}
     steps:
       - name: Checkout Repository
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
-      - name: Set up QEMU for ARM64
-        if: (matrix.architecture == 'linux/arm64' && github.ref == 'refs/heads/main') || (matrix.architecture == 'linux/arm64' && github.event_name == 'release' && github.event.action == 'published')
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-          image: tonistiigi/binfmt:qemu-v8.1.5 # https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2611042596
       - name: Login to DockerHub
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull Development Image
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Build C++ Package
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: make build-packages-cpp-standalone TARGETPLATFORM=${{ matrix.architecture }}
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: make build-packages-cpp-standalone TARGETPLATFORM=${{ matrix.architecture.platform }}
       - name: Format artifact name
         id: format-artifact-name
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
-          artifact_name=$(echo "${{ matrix.architecture }}" | tr / -)
+          artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
           echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload C++ Package
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
@@ -73,44 +71,42 @@ jobs:
 
   build-package-python:
     name: Build Python Package
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        architecture: [linux/amd64, linux/arm64]
+        architecture:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.architecture.runner }}
     steps:
       - name: Checkout Repository
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
-      - name: Set up QEMU for ARM64
-        if: (matrix.architecture == 'linux/arm64' && github.ref == 'refs/heads/main') || (matrix.architecture == 'linux/arm64' && github.event_name == 'release' && github.event.action == 'published')
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-          image: tonistiigi/binfmt:qemu-v8.1.5 # https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2611042596
       - name: Login to DockerHub
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull Development Image
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Build Python Package
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: make build-packages-python-standalone TARGETPLATFORM=${{ matrix.architecture }}
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: make build-packages-python-standalone TARGETPLATFORM=${{ matrix.architecture.platform }}
       - name: Format artifact name
         id: format-artifact-name
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
-          artifact_name=$(echo "${{ matrix.architecture }}" | tr / -)
+          artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
           echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload Python Package
-        if: matrix.architecture != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   deploy-package-cpp:
     name: Deploy C++ Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   deploy-package-python:
     name: Deploy Python Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
 
   deploy-documentation:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -99,7 +99,7 @@ jobs:
 
   deploy-image-jupyter:
     name: Deploy Jupyter Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   format-check-cpp:
     name: Check C++ Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
   test-unit-cpp:
     name: Run C++ Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
 
   format-check-python:
     name: Check Python Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
 
   build-python:
     name: Build Python bindings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       python_versions: ${{ steps.python-versions.outputs.value }}
     steps:
@@ -121,7 +121,7 @@ jobs:
 
   test-unit-python:
     name: Run Python Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-python
     strategy:


### PR DESCRIPTION
Uses dedicated ARM runners for ARM builds rather than using QEMU, thanks to them [now being available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) in Public Preview. This speeds up pipelines by roughly 4-8x: 
- ~4h to 30min in the [base image in this repo](https://github.com/open-space-collective/open-space-toolkit/actions/runs/16169586194)
- ~1h to 18min in [ostk-maths](https://github.com/open-space-collective/open-space-toolkit-mathematics/actions/runs/16169595387)

Now that the images are built on separate runners, we need to merge them in Docker so that they are still grouped as a single multi-arch image, following the instructions [here](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners). 


Also pins ubuntu runners explicitly to 24.04


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all GitHub Actions workflows to use the `ubuntu-24.04` runner environment for improved consistency and reliability.
  * Enhanced multi-architecture Docker image builds and manifest merging for development images.
  * Improved package build workflows to support dynamic runner selection and multi-platform builds.
  * Removed unnecessary QEMU setup steps from relevant workflows.
  * Minor formatting cleanup in workflow files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->