### PR TITLE
ci: cache docker-build per-platform

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,8 +69,8 @@ jobs:
           build-args: |
             BASE_IMAGE_SYSTEM=debian
             VERSION=${{ inputs.project_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.architecture.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.architecture.platform }}
           target: ${{ inputs.target }}
           platforms: ${{ matrix.architecture.platform }}
           push: ${{ inputs.push }}


### PR DESCRIPTION
Resolves https://github.com/open-space-collective/open-space-toolkit/issues/177

Using [this PR](https://github.com/open-space-collective/open-space-toolkit-core/pull/194) to test:

Running as-is: 
[Pipeline A](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/17208714045/attempts/1): Fresh run, both images must build. AMD finishes first.

[Pipeline B](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/17208714045): Re-run with no code changes. [ARM](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/17208714045/job/48816027758) gets the cache hit, since it finished second in Pipeline A. AMD builds from scratch.

--- 
Now [using](https://github.com/open-space-collective/open-space-toolkit-core/pull/194/commits/bf0ccbe0ad2db780799714dc4096c93a56e6b973) this change:
[Pipeline C](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/17209367956/attempts/1): Cache key now includes `scope`, so both images miss the existing cache and must rebuild. (took ~10 mins)

[Pipeline D](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/17209367956): Re-run with no code changes. Cache hit on both platforms ✅. (took ~8 mins)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build pipeline by scoping image caches per architecture, reducing cache conflicts and improving consistency for multi-architecture builds.
  * Expect faster and more reliable build times during releases and CI runs, with more predictable artifacts across platforms.
  * No user-facing changes; application behavior and features remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->