### PR TITLE
build: manage Python with uv, upgrade project

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -32,12 +32,24 @@ jobs:
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    defaults:
-      run:
-        working-directory: /app
     steps:
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-result
+          path: /app/bin/benchmark_result.json
+
+  benchmark-cpp-report:
+    name: Report C++ Benchmark
+    needs: benchmark-cpp
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download benchmark result
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-result
       - name: Download previous benchmark
         uses: actions/cache@v3
         with:
@@ -46,7 +58,8 @@ jobs:
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "googlecpp"
-          output-file-path: /app/bin/benchmark_result.json
+          output-file-path: benchmark_result.json
+          external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "200%"

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -28,11 +28,20 @@ jobs:
     name: Benchmark C++
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.project_version }}
+          path: ${{ github.workspace }}/artifacts
+      - name: Restore binaries
+        run: |
+          mkdir -p /app/bin
+          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Upload benchmark result
@@ -69,10 +78,19 @@ jobs:
     name: Run C++ Validation Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.project_version }}
+          path: ${{ github.workspace }}/artifacts
+      - name: Restore binaries
+        run: |
+          mkdir -p /app/bin
+          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run C++ Validation Tests
         run: /app/bin/${{ inputs.project_name }}.validation

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -32,6 +32,9 @@ jobs:
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    defaults:
+      run:
+        working-directory: /app
     steps:
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -27,21 +27,14 @@ jobs:
   benchmark-cpp:
     name: Benchmark C++
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Run C++ Benchmark
-        run: make benchmark-cpp-standalone
+        run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Download previous benchmark
         uses: actions/cache@v3
         with:
@@ -50,7 +43,7 @@ jobs:
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "googlecpp"
-          output-file-path: bin/benchmark_result.json
+          output-file-path: /app/bin/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "200%"
@@ -59,18 +52,11 @@ jobs:
   validation-cpp:
     name: Run C++ Validation Tests
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Run C++ Validation Tests
-        run: make validation-cpp-standalone
+        run: /app/bin/${{ inputs.project_name }}.validation

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -28,11 +28,13 @@ jobs:
     name: Benchmark C++
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - name: Build
+        run: cd /app && make _build-test
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Upload benchmark result
@@ -69,10 +71,12 @@ jobs:
     name: Run C++ Validation Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - name: Build
+        run: cd /app && make _build-test
       - name: Run C++ Validation Tests
         run: /app/bin/${{ inputs.project_name }}.validation

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -28,20 +28,11 @@ jobs:
     name: Benchmark C++
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.project_version }}
-          path: ${{ github.workspace }}/artifacts
-      - name: Restore binaries
-        run: |
-          mkdir -p /app/bin
-          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Upload benchmark result
@@ -78,19 +69,10 @@ jobs:
     name: Run C++ Validation Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.project_version }}
-          path: ${{ github.workspace }}/artifacts
-      - name: Restore binaries
-        run: |
-          mkdir -p /app/bin
-          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run C++ Validation Tests
         run: /app/bin/${{ inputs.project_name }}.validation

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-result
           path: /app/bin/benchmark_result.json
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download benchmark result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: benchmark-result
       - name: Download previous benchmark
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -34,7 +34,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Build
-        run: cd /app && make _build-test
+        run: cd /app && make _build-benchmark-cpp
       - name: Run C++ Benchmark
         run: /app/bin/${{ inputs.project_name }}.benchmark --benchmark_out_format=json --benchmark_out=/app/bin/benchmark_result.json
       - name: Upload benchmark result
@@ -77,6 +77,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Build
-        run: cd /app && make _build-test
+        run: cd /app && make _build-validation-cpp
       - name: Run C++ Validation Tests
         run: /app/bin/${{ inputs.project_name }}.validation

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -26,7 +26,7 @@ jobs:
       project_version: ${{ steps.project-version.outputs.value }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,6 +69,7 @@ jobs:
           build-args: |
             BASE_IMAGE_SYSTEM=debian
             VERSION=${{ inputs.project_version }}
+            TARGETPLATFORM=${{ matrix.architecture.platform }}
           cache-from: type=gha,scope=${{ matrix.architecture.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.architecture.platform }}
           target: ${{ inputs.target }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -48,20 +48,20 @@ jobs:
     runs-on: ${{ matrix.architecture.runner }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Development Image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           tags: ${{ env.IMAGE_NAME }}
           context: .
@@ -88,7 +88,7 @@ jobs:
           echo "PLATFORM_PATH=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Upload Digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PATH }}
           path: ${{ runner.temp }}/digests/*
@@ -102,17 +102,17 @@ jobs:
       - build-image-development
     steps:
       - name: Download Digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: cpp-package-${{ env.ARTIFACT_NAME }}
-          path: packages/cpp/
+          path: /app/packages/cpp/
       - name: Upload Python Package
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
@@ -67,11 +67,11 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: python-package-${{ env.ARTIFACT_NAME }}
-          path: packages/python/
+          path: /app/packages/python/
       - name: Tar files
         run: cd /app && tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
         uses: actions/upload-artifact@v6
         with:
           name: docs
-          path: docs.tar.gz
+          path: /app/docs.tar.gz

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -24,10 +24,10 @@ env:
   LANG: en_US.UTF-8
 
 jobs:
-  build-package-cpp:
-    name: Build C++ Package
+  build-packages:
+    name: Build all pacakages
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         architecture:
           - platform: linux/amd64
@@ -35,105 +35,41 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.architecture.runner }}
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout Repository
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Build C++ Package
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: make build-packages-cpp-standalone TARGETPLATFORM=${{ matrix.architecture.platform }}
+      - name: Build Packages
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: cd /app && make _build-all-packages
+        env:
+          CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
       - name: Format artifact name
         id: format-artifact-name
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
           artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
           echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload C++ Package
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
           name: cpp-package-${{ env.ARTIFACT_NAME }}
           path: packages/cpp/
-
-  build-package-python:
-    name: Build Python Package
-    strategy:
-      fail-fast: false
-      matrix:
-        architecture:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.architecture.runner }}
-    steps:
-      - name: Checkout Repository
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Build Python Package
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: make build-packages-python-standalone TARGETPLATFORM=${{ matrix.architecture.platform }}
-      - name: Format artifact name
-        id: format-artifact-name
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: |
-          artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
-          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload Python Package
-        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v4
         with:
           name: python-package-${{ env.ARTIFACT_NAME }}
           path: packages/python/
-
-  build-documentation:
-    name: Build Documentation
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Documentation
-        env:
-          CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
-        run: make build-documentation-standalone
       - name: Tar files
-        run: tar -cvf docs.tar.gz docs/
+        run: cd /app && tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -56,7 +56,7 @@ jobs:
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cpp-package-${{ env.ARTIFACT_NAME }}
           path: packages/cpp/
@@ -64,14 +64,14 @@ jobs:
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-${{ env.ARTIFACT_NAME }}
           path: packages/python/
       - name: Tar files
         run: cd /app && tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs
           path: docs.tar.gz

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -42,16 +42,16 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Build C++ Package
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: cd /app && make _build-package-cpp
       - name: Format artifact name
         id: format-artifact-name
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
           artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
           echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload C++ Package
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v6
@@ -77,16 +77,16 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Build Python Package
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: cd /app && make _build-package-python
       - name: Format artifact name
         id: format-artifact-name
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
           artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
           echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload Python Package
-        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
           ARTIFACT_NAME: ${{ steps.format-artifact-name.outputs.ARTIFACT_NAME }}
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -24,8 +24,8 @@ env:
   LANG: en_US.UTF-8
 
 jobs:
-  build-packages:
-    name: Build all packages
+  build-package-cpp:
+    name: Build C++ Package
     strategy:
       fail-fast: true
       matrix:
@@ -41,11 +41,9 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Build Packages
+      - name: Build C++ Package
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: cd /app && make _build-release-packages
-        env:
-          CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
+        run: cd /app && make _build-package-cpp
       - name: Format artifact name
         id: format-artifact-name
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
@@ -60,6 +58,33 @@ jobs:
         with:
           name: cpp-package-${{ env.ARTIFACT_NAME }}
           path: /app/packages/cpp/
+
+  build-package-python:
+    name: Build Python Package
+    strategy:
+      fail-fast: true
+      matrix:
+        architecture:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.architecture.runner }}
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Build Python Package
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: cd /app && make _build-package-python
+      - name: Format artifact name
+        id: format-artifact-name
+        # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+        run: |
+          artifact_name=$(echo "${{ matrix.architecture.platform }}" | tr / -)
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_OUTPUT
       - name: Upload Python Package
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
         env:
@@ -68,11 +93,23 @@ jobs:
         with:
           name: python-package-${{ env.ARTIFACT_NAME }}
           path: /app/packages/python/
+
+  build-documentation:
+    name: Build Documentation
+    runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Build Documentation
+        run: cd /app && make _build-documentation
+        env:
+          CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
       - name: Tar files
-        if: matrix.architecture.platform == 'linux/amd64'
         run: cd /app && tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
-        if: matrix.architecture.platform == 'linux/amd64'
         uses: actions/upload-artifact@v6
         with:
           name: docs

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Build Packages
         # if: matrix.architecture.platform != 'linux/arm64' || github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
-        run: cd /app && make _build-all-packages
+        run: cd /app && make _build-release-packages
         env:
           CESIUM_TOKEN: ${{ secrets.CESIUM_TOKEN }}
       - name: Format artifact name

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -69,8 +69,10 @@ jobs:
           name: python-package-${{ env.ARTIFACT_NAME }}
           path: /app/packages/python/
       - name: Tar files
+        if: matrix.architecture.platform == 'linux/amd64'
         run: cd /app && tar -cvf docs.tar.gz docs/
       - name: Upload Documentation
+        if: matrix.architecture.platform == 'linux/amd64'
         uses: actions/upload-artifact@v6
         with:
           name: docs

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-packages:
-    name: Build all packages
+    name: Build all pacakages
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-packages:
-    name: Build all pacakages
+    name: Build all packages
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,17 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Download C++ Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: cpp-package-*
           merge-multiple: true
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
       - name: Download Python Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: python-package-*
           merge-multiple: true
@@ -81,12 +81,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
       - name: Download Documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs
       - name: Untar Files
@@ -102,19 +102,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Jupyter Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           tags: |
             ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-jupyter:${{ inputs.project_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,18 +59,18 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Build Test Image
         id: build-test-image
         uses: docker/build-push-action@v6
         with:
-          tags: openspacecollective/${{ inputs.project_name }}-test
+          tags: ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
           context: .
           file: ./docker/development/Dockerfile
           build-args: |
@@ -80,9 +80,6 @@ jobs:
           cache-to: type=gha,mode=max
           target: ci-test
           push: true
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-      - name: Push Test Image
-        run: docker push ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       - name: Export Python Versions
         id: python-versions
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,12 +101,13 @@ jobs:
     steps:
       - name: Run Unit Tests C++
         run: |
+          cd /app/build
           make coverage
       - name: Upload Coverage Results
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/
+          directory: /app/build/
           fail_ci_if_error: true
 
   test-unit-python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,81 +48,27 @@ jobs:
       - name: Check Python Format
         run: ostk-check-format-python
 
-  build-test-image:
-    name: Build Test Image
-    runs-on: ubuntu-24.04
-    outputs:
-      python_versions: ${{ steps.python-versions.outputs.value }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Test Image
-        id: build-test-image
-        uses: docker/build-push-action@v6
-        with:
-          tags: ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
-          context: .
-          file: ./docker/development/Dockerfile
-          build-args: |
-            BASE_IMAGE_SYSTEM=debian
-            VERSION=${{ inputs.project_version }}
-          cache-from: type=gha,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
-          cache-to: type=gha,mode=max,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
-          target: ci-test
-          push: true
-      - name: Export Python Versions
-        id: python-versions
-        run: |
-          python_versions=$(docker run --rm ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }} \
-            bash -c "echo -n '['; ls -d /app/build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed 's/.*/\"\0\"/' | tr '\n' ',' | sed 's/,$//'; echo ']'")
-          echo "Python versions: ${python_versions}"
-          echo "value=${python_versions}" >> $GITHUB_OUTPUT
-
-  test-unit-cpp:
-    name: Run C++ Unit Tests
+  test:
+    name: Build and Test
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    needs:
-      - build-test-image
     steps:
-      - name: Run Unit Tests C++
-        run: |
-          cd /app/build
-          make coverage
+      - name: Build
+        run: cd /app && make _build-test
+      - name: Run C++ Unit Tests
+        run: cd /app/build && make coverage
       - name: Upload Coverage Results
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /app/build/coverage.info
           fail_ci_if_error: true
-
-  test-unit-python:
-    name: Run Python Unit Tests
-    runs-on: ubuntu-24.04
-    container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    needs:
-      - build-test-image
-    strategy:
-      matrix:
-        python-version: ${{ fromJson(needs.build-test-image.outputs.python_versions) }}
-    steps:
-      - name: Run Unit Tests Python
-        run: ${{ format('OSTK_PYTHON_VERSION={0}', matrix.python-version) }} ostk-test-python
+      - name: Run Python Unit Tests
+        run: |
+          for version in $(ls /app/build/bindings/python/ | grep -oE '[0-9]+\.[0-9]+$' | sort -u); do
+            OSTK_PYTHON_VERSION=${version} ostk-test-python
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
     name: Check C++ Format
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{
-        inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -41,8 +40,7 @@ jobs:
     name: Check Python Format
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{
-        inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -54,8 +52,7 @@ jobs:
     name: Run C++ Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{
-        inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -65,7 +62,7 @@ jobs:
       - name: Run C++ Unit Tests With Coverage
         run: cd /app/build && make coverage
       - name: Upload Coverage Results
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /app/build/coverage.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - id: python-versions
         name: Export Python Versions to Environment
         run: |
-          python_versions=$(echo -n "["; find packages/python -name "*.whl" | grep -o "py[0-9]\{2,3\}" | sed 's/py\([0-9]\)\([0-9][0-9]\?\)/\1.\2/' | sed "s/\([0-9.]*\)/'\1'/" | tr '\n' ',' | sed 's/,$//'; echo "]")
+          python_versions=$(echo -n "["; find packages/python -name "*.whl" | grep -o -E "cp[0-9]{2,3}" | sed 's/cp\([0-9]\)\([0-9][0-9]\?\)/\1.\2/' | sed "s/\([0-9.]*\)/'\1'/" | tr '\n' ',' | sed 's/,$//'; echo "]")
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,40 +27,26 @@ jobs:
   format-check-cpp:
     name: Check C++ Format
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Check C++ Format
-        run: make format-check-cpp-standalone
+        run: ostk-check-format-cpp
 
   format-check-python:
     name: Check Python Format
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Check Python Format
-        run: make format-check-python-standalone
+        run: ostk-check-format-python
 
   build-test-image:
     name: Build Test Image
@@ -81,7 +67,20 @@ jobs:
       - name: Pull Development Image
         run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       - name: Build Test Image
-        run: make build-test-image
+        id: build-test-image
+        uses: docker/build-push-action@v6
+        with:
+          tags: openspacecollective/${{ inputs.project_name }}-test
+          context: .
+          file: ./docker/development/Dockerfile
+          build-args: |
+            BASE_IMAGE_SYSTEM=debian
+            VERSION=${{ inputs.project_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: ci-test
+          push: true
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
       - name: Push Test Image
         run: docker push ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       - name: Export Python Versions
@@ -107,4 +106,4 @@ jobs:
         python-version: ${{ fromJson(needs.build-test-image.outputs.python_versions) }}
     steps:
       - name: Run Unit Tests Python
-        run: make ci-test-python ${{ format('test_python_version={0}', matrix.python-version) }}
+        run: ${{ format('OSTK_PYTHON_VERSION={0}', matrix.python-version) }} ostk-test-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,62 +48,57 @@ jobs:
       - name: Check Python Format
         run: ostk-check-format-python
 
-  build-artifacts:
-    name: Build Artifacts
+  build-test-image:
+    name: Build Test Image
     runs-on: ubuntu-24.04
-    container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:
       python_versions: ${{ steps.python-versions.outputs.value }}
     steps:
-      - name: Build artifacts
-        run: cd /app && make _build-test
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build Test Image
+        id: build-test-image
+        uses: docker/build-push-action@v6
+        with:
+          tags: ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+          context: .
+          file: ./docker/development/Dockerfile
+          build-args: |
+            BASE_IMAGE_SYSTEM=debian
+            VERSION=${{ inputs.project_version }}
+          cache-from: type=gha,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
+          cache-to: type=gha,mode=max,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
+          target: ci-test
+          push: true
       - name: Export Python Versions
         id: python-versions
         run: |
-          python_versions=$(ls /app/build/bindings/python/ \
-            | grep -oE '[0-9]+\.[0-9]+$' \
-            | sort -Vu \
-            | sed 's/.*/"\0"/' \
-            | paste -sd ',' \
-            | sed 's/^/[/' | sed 's/$/]/')
+          python_versions=$(docker run --rm ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }} \
+            bash -c "echo -n '['; ls -d /app/build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed 's/.*/\"\0\"/' | tr '\n' ',' | sed 's/,$//'; echo ']'")
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
-      - name: Copy artifacts to workspace
-        run: |
-          cp -a /app/build $GITHUB_WORKSPACE/build
-          cp -a /app/bin $GITHUB_WORKSPACE/bin
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.project_version }}
-          path: ${{ github.workspace }}/
-          retention-days: 1
 
   test-unit-cpp:
     name: Run C++ Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     needs:
-      - build-artifacts
+      - build-test-image
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.project_version }}
-          path: ${{ github.workspace }}/artifacts
-      - name: Restore build artifacts
-        run: |
-          cp -a $GITHUB_WORKSPACE/artifacts/build/. /app/build/
-          mkdir -p /app/bin
-          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run Unit Tests C++
         run: |
           cd /app/build
@@ -119,25 +114,15 @@ jobs:
     name: Run Python Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     needs:
-      - build-artifacts
+      - build-test-image
     strategy:
       matrix:
-        python-version: ${{ fromJson(needs.build-artifacts.outputs.python_versions) }}
+        python-version: ${{ fromJson(needs.build-test-image.outputs.python_versions) }}
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.project_version }}
-          path: ${{ github.workspace }}/artifacts
-      - name: Restore build artifacts
-        run: |
-          cp -a $GITHUB_WORKSPACE/artifacts/build/. /app/build/
-          mkdir -p /app/bin
-          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run Unit Tests Python
         run: ${{ format('OSTK_PYTHON_VERSION={0}', matrix.python-version) }} ostk-test-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Check Python Format
         run: make format-check-python-standalone
 
-  build-tests-and-coverage:
-    name: Build all tests and run coverage
+  build-test-image:
+    name: Build Test Image
     runs-on: ubuntu-24.04
     outputs:
       python_versions: ${{ steps.python-versions.outputs.value }}
@@ -80,51 +80,31 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull Development Image
         run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Run Coverage
-        run: make build-tests
-      - name: Upload Coverage Results
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/
-          fail_ci_if_error: true
-      - name: Upload Python Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-bindings # TBM: use a different namespace than in build-packages for now.
-          path: build/bindings/python
-      - id: python-versions
-        name: Export Python Versions to Environment
+      - name: Build Test Image
+        run: make build-test-image
+      - name: Push Test Image
+        run: docker push ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      - name: Export Python Versions
+        id: python-versions
         run: |
-          python_versions=$(echo -n "["; ls -d build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed "s/\(.*\)/'\1'/" | tr '\n' ',' | sed 's/,$//'; echo "]")
+          python_versions=$(docker run --rm ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }} \
+            bash -c "echo -n '['; ls -d /app/build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed 's/.*/\"\0\"/' | tr '\n' ',' | sed 's/,$//'; echo ']'")
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
 
   test-unit-python:
     name: Run Python Unit Tests
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     needs:
-      - build-tests-and-coverage
+      - build-test-image
     strategy:
       matrix:
-        python-version: ${{ fromJson(needs.build-tests-and-coverage.outputs.python_versions) }}
+        python-version: ${{ fromJson(needs.build-test-image.outputs.python_versions) }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Download Python packages
-        uses: actions/download-artifact@v4
-        with:
-          name: python-bindings
-          path: build/bindings/python
       - name: Run Unit Tests Python
         run: make ci-test-python ${{ format('test_python_version={0}', matrix.python-version) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,31 +43,6 @@ jobs:
       - name: Check C++ Format
         run: make format-check-cpp-standalone
 
-  test-unit-cpp:
-    name: Run C++ Unit Tests
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Pull Development Image
-        run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Run Unit Tests C++
-        run: make test-coverage-cpp-standalone
-      - name: Upload Coverage Results
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/
-          fail_ci_if_error: true
-
   format-check-python:
     name: Check Python Format
     runs-on: ubuntu-24.04
@@ -87,11 +62,9 @@ jobs:
       - name: Check Python Format
         run: make format-check-python-standalone
 
-  build-python:
-    name: Build Python bindings
+  build-tests-and-coverage:
+    name: Build all tests and run coverage
     runs-on: ubuntu-24.04
-    outputs:
-      python_versions: ${{ steps.python-versions.outputs.value }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -105,17 +78,23 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pull Development Image
         run: docker pull ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-      - name: Build Python Bindings
-        run: make build-packages-python-standalone
-      - name: Upload Python Bindings
+      - name: Run Coverage
+        run: make build-tests
+      - name: Upload Coverage Results
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/
+          fail_ci_if_error: true
+      - name: Upload Python Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: python-bindings # TBM: use a different namespace than in build-packages for now.
-          path: packages/python/
+          path: build/bindings/python
       - id: python-versions
         name: Export Python Versions to Environment
         run: |
-          python_versions=$(echo -n "["; find packages/python -name "*.whl" | grep -o -E "cp[0-9]{2,3}" | sed 's/cp\([0-9]\)\([0-9][0-9]\?\)/\1.\2/' | sed "s/\([0-9.]*\)/'\1'/" | tr '\n' ',' | sed 's/,$//'; echo "]")
+          python_versions=$(echo -n "["; ls -d build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed "s/\(.*\)/'\1'/" | tr '\n' ',' | sed 's/,$//'; echo "]")
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
 
@@ -123,10 +102,10 @@ jobs:
     name: Run Python Unit Tests
     runs-on: ubuntu-24.04
     needs:
-      - build-python
+      - build-tests-and-coverage
     strategy:
       matrix:
-        python-version: ${{ fromJson(needs.build-python.outputs.python_versions) }}
+        python-version: ${{ fromJson(needs.build-tests-and-coverage.outputs.python_versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -144,6 +123,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: python-bindings
-          path: packages/python/
+          path: build/bindings/python
       - name: Run Unit Tests Python
         run: make ci-test-python ${{ format('test_python_version={0}', matrix.python-version) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,8 @@ jobs:
   build-tests-and-coverage:
     name: Build all tests and run coverage
     runs-on: ubuntu-24.04
+    outputs:
+      python_versions: ${{ steps.python-versions.outputs.value }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
     name: Check C++ Format
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{
+        inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,7 +41,8 @@ jobs:
     name: Check Python Format
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{
+        inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -48,18 +50,19 @@ jobs:
       - name: Check Python Format
         run: ostk-check-format-python
 
-  test:
-    name: Build and Test
+  test-cpp:
+    name: Run C++ Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{
+        inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
-      - name: Build
-        run: cd /app && make _build-test
-      - name: Run C++ Unit Tests
+      - name: Build C++ Tests
+        run: cd /app && make _build-test-cpp
+      - name: Run C++ Unit Tests With Coverage
         run: cd /app/build && make coverage
       - name: Upload Coverage Results
         uses: codecov/codecov-action@v5
@@ -67,6 +70,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /app/build/coverage.info
           fail_ci_if_error: true
+
+  test-python:
+    name: Run Python Unit Tests
+    runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Build Python Tests
+        run: cd /app && make _build-test-python
       - name: Run Python Unit Tests
         run: |
           for version in $(ls /app/build/bindings/python/ | grep -oE '[0-9]+\.[0-9]+$' | sort -u); do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,10 +104,10 @@ jobs:
           cd /app/build
           make coverage
       - name: Upload Coverage Results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: /app/build/
+          files: /app/build/coverage.info
           fail_ci_if_error: true
 
   test-unit-python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,57 +48,62 @@ jobs:
       - name: Check Python Format
         run: ostk-check-format-python
 
-  build-test-image:
-    name: Build Test Image
+  build-artifacts:
+    name: Build Artifacts
     runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:
       python_versions: ${{ steps.python-versions.outputs.value }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Test Image
-        id: build-test-image
-        uses: docker/build-push-action@v6
-        with:
-          tags: ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }}
-          context: .
-          file: ./docker/development/Dockerfile
-          build-args: |
-            BASE_IMAGE_SYSTEM=debian
-            VERSION=${{ inputs.project_version }}
-          cache-from: type=gha,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
-          cache-to: type=gha,mode=max,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
-          target: ci-test
-          push: true
+      - name: Build artifacts
+        run: cd /app && make _build-test
       - name: Export Python Versions
         id: python-versions
         run: |
-          python_versions=$(docker run --rm ${{ env.DOCKER_REGISTRY_PATH }}/${{ inputs.project_name }}-test:${{ inputs.project_version }} \
-            bash -c "echo -n '['; ls -d /app/build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed 's/.*/\"\0\"/' | tr '\n' ',' | sed 's/,$//'; echo ']'")
+          python_versions=$(ls /app/build/bindings/python/ \
+            | grep -oE '[0-9]+\.[0-9]+$' \
+            | sort -Vu \
+            | sed 's/.*/"\0"/' \
+            | paste -sd ',' \
+            | sed 's/^/[/' | sed 's/$/]/')
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
+      - name: Copy artifacts to workspace
+        run: |
+          cp -a /app/build $GITHUB_WORKSPACE/build
+          cp -a /app/bin $GITHUB_WORKSPACE/bin
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.project_version }}
+          path: ${{ github.workspace }}/
+          retention-days: 1
 
   test-unit-cpp:
     name: Run C++ Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     needs:
-      - build-test-image
+      - build-artifacts
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.project_version }}
+          path: ${{ github.workspace }}/artifacts
+      - name: Restore build artifacts
+        run: |
+          cp -a $GITHUB_WORKSPACE/artifacts/build/. /app/build/
+          mkdir -p /app/bin
+          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run Unit Tests C++
         run: |
           cd /app/build
@@ -114,15 +119,25 @@ jobs:
     name: Run Python Unit Tests
     runs-on: ubuntu-24.04
     container:
-      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      image: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     needs:
-      - build-test-image
+      - build-artifacts
     strategy:
       matrix:
-        python-version: ${{ fromJson(needs.build-test-image.outputs.python_versions) }}
+        python-version: ${{ fromJson(needs.build-artifacts.outputs.python_versions) }}
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.project_version }}
+          path: ${{ github.workspace }}/artifacts
+      - name: Restore build artifacts
+        run: |
+          cp -a $GITHUB_WORKSPACE/artifacts/build/. /app/build/
+          mkdir -p /app/bin
+          cp -a $GITHUB_WORKSPACE/artifacts/bin/. /app/bin/
       - name: Run Unit Tests Python
         run: ${{ format('OSTK_PYTHON_VERSION={0}', matrix.python-version) }} ostk-test-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,9 @@ jobs:
         run: cd /app && make _build-test-cpp
       - name: Run C++ Unit Tests With Coverage
         run: cd /app/build && make coverage
+      - uses: actions/checkout@v6 # Required for codecov
       - name: Upload Coverage Results
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /app/build/coverage.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,8 @@ jobs:
           build-args: |
             BASE_IMAGE_SYSTEM=debian
             VERSION=${{ inputs.project_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
+          cache-to: type=gha,mode=max,scope=linux/amd64 # corresponding `platform` name for the `runner`, defined in build-image.yml
           target: ci-test
           push: true
       - name: Export Python Versions
@@ -87,6 +87,27 @@ jobs:
             bash -c "echo -n '['; ls -d /app/build/bindings/python/OpenSpaceToolkit*-python-package-*/ | grep -o -E '[0-9]+\.[0-9]+' | sed 's/.*/\"\0\"/' | tr '\n' ',' | sed 's/,$//'; echo ']'")
           echo "Python versions: ${python_versions}"
           echo "value=${python_versions}" >> $GITHUB_OUTPUT
+
+  test-unit-cpp:
+    name: Run C++ Unit Tests
+    runs-on: ubuntu-24.04
+    container:
+      image: openspacecollective/${{ inputs.project_name }}-test:${{ inputs.project_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    needs:
+      - build-test-image
+    steps:
+      - name: Run Unit Tests C++
+        run: |
+          make coverage
+      - name: Upload Coverage Results
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/
+          fail_ci_if_error: true
 
   test-unit-python:
     name: Run Python Unit Tests

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /tmp \
    && cd googletest \
    && mkdir build \
    && cd build \
-   && /opt/cmake/bin/cmake .. -DCMAKE_INSTALL_PREFIX=/opt/googletest \
+   && /opt/cmake/bin/cmake .. -DCMAKE_INSTALL_PREFIX=/opt/googletest -DCMAKE_BUILD_TYPE=Release \
    && make -j $(nproc) \
    && make install \
    && rm -rf /tmp/googletest
@@ -77,8 +77,18 @@ RUN mkdir -p /tmp/boost \
    && tar -xf boost_${BOOST_VERSION}.tar.gz \
    && cd boost_${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_0 \
    && ./bootstrap.sh --prefix=/opt/boost \
-   && ./b2 -j $(nproc) link=shared cxxflags=-fPIC install \
-   && ./b2 -j $(nproc) link=static cxxflags=-fPIC install \
+   && ./b2 -j $(nproc) link=shared,static cxxflags=-fPIC \
+   --with-atomic \
+   --with-chrono \
+   --with-date_time \
+   --with-filesystem \
+   --with-log \
+   --with-math \
+   --with-regex \
+   --with-stacktrace \
+   --with-system \
+   --with-thread \
+   install \
    && rm -rf /tmp/boost
 
 # OpenSSL builder
@@ -110,14 +120,12 @@ RUN alias ls='ls --color=auto' \
 
 ARG CLANG_VERSION="18"
 
-RUN mkdir -p /tmp/clang \
-   && cd /tmp/clang \
-   && wget https://apt.llvm.org/llvm.sh \
-   && chmod +x llvm.sh \
-   && ./llvm.sh ${CLANG_VERSION} all \
-   && rm -rf /tmp/clang \
-   && ln -s /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format \
-   && ln -s /usr/bin/clang-${CLANG_VERSION} /usr/bin/clang
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+   && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
+   && apt-get update \
+   && apt-get install -y --no-install-recommends clang-format-${CLANG_VERSION} \
+   && rm -rf /var/lib/apt/lists/* \
+   && ln -s /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format
 
 ## GCC / G++
 
@@ -129,9 +137,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130
 
 ## uv / Python
-ARG UV_VERSION="0.10.6"
-
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.6 /uv /uvx /bin/
 
 ARG OSTK_PYTHON_VERSION="3.11"
 ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -134,7 +134,8 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && apt-get install -y gcc-13 g++-13 \
    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \
-   && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130
+   && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130 \
+   && rm -rf /var/lib/apt/lists/*
 
 ## uv / Python
 COPY --from=ghcr.io/astral-sh/uv:0.10.6 /uv /uvx /bin/

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,7 +1,13 @@
 # Apache License 2.0
 
+ARG UBUNTU_VERSION="20.04"
+ARG UV_VERSION="0.11.7"
+
+# uv binary
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-binary
+
 # Common system packages
-FROM ubuntu:20.04 AS system-packages
+FROM ubuntu:${UBUNTU_VERSION} AS system-packages
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -138,7 +144,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && rm -rf /var/lib/apt/lists/*
 
 ## uv / Python
-COPY --from=ghcr.io/astral-sh/uv:0.10.6 /uv /uvx /bin/
+COPY --from=uv-binary /uv /uvx /bin/
 
 ARG OSTK_PYTHON_VERSION="3.11"
 ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -99,14 +99,14 @@ RUN mkdir -p /tmp/boost \
 # OpenSSL builder
 FROM system-packages AS openssl-builder
 
-ARG OPENSSL_VERSION="3.0.2"
+ARG OPENSSL_VERSION="3.0.20"
 
 RUN mkdir -p /tmp/openssl \
    && cd /tmp/openssl \
    && wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
    && tar -xf openssl-${OPENSSL_VERSION}.tar.gz \
    && cd openssl-${OPENSSL_VERSION} \
-   && ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib \
+   && ./config --prefix=/opt/openssl --openssldir=/etc/ssl shared zlib \
    && make -j $(nproc) \
    && make install \
    && rm -rf /tmp/openssl
@@ -146,11 +146,7 @@ ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"
 ENV UV_PYTHON_INSTALL_DIR="/opt/uv-python"
 ENV UV_LINK_MODE="copy"
 
-RUN uv python install 3.9 \
-   && uv python install 3.10 \
-   && uv python install 3.11 \
-   && uv python install 3.12 \
-   && uv python install 3.13 \
+RUN uv python install 3.9 3.10 3.11 3.12 3.13 \
    && chmod -R 777 ${UV_PYTHON_INSTALL_DIR} \
    && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python \
    && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python${OSTK_PYTHON_VERSION} \
@@ -191,8 +187,8 @@ COPY --from=boost-builder /opt/boost/lib /usr/local/lib
 
 COPY --from=openssl-builder /opt/openssl /usr/local/ssl
 
-RUN touch /etc/ld.so.conf.d/openssl.conf \
-   && echo "/usr/local/ssl/lib64" >> /etc/ld.so.conf.d/openssl.conf \
+RUN echo "/usr/local/ssl/lib64" >> /etc/ld.so.conf.d/openssl.conf \
+   && echo "/usr/local/ssl/lib" >> /etc/ld.so.conf.d/openssl.conf \
    && ldconfig \
    && mv /usr/local/ssl/bin/c_rehash /usr/bin/c_rehash \
    && mv /usr/local/ssl/bin/openssl /usr/bin/openssl

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -147,10 +147,7 @@ RUN uv python install 3.9 \
    && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python${OSTK_PYTHON_VERSION} \
    && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python3
 
-# Create a venv for the default OSTk Python version. 
-ENV OSTK_VIRTUAL_ENV=/opt/ostk-venv
-RUN uv venv ${OSTK_VIRTUAL_ENV} --python ${OSTK_PYTHON_VERSION} \
-   && chmod -R 777 ${OSTK_VIRTUAL_ENV}
+ENV PYTHON_WD="/app/bindings/python"
 
 ## CMake
 
@@ -194,7 +191,6 @@ RUN touch /etc/ld.so.conf.d/openssl.conf \
 # Environment
 
 ENV LD_LIBRARY_PATH="/usr/local/lib"
-ENV PYTHONPATH="/usr/local/lib"
 RUN git config --global --add safe.directory /app
 
 # Install development helpers

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,13 +1,12 @@
 # Apache License 2.0
 
-ARG UBUNTU_VERSION="20.04"
 ARG UV_VERSION="0.11.7"
 
 # uv binary
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-binary
 
 # Common system packages
-FROM ubuntu:${UBUNTU_VERSION} AS system-packages
+FROM ubuntu:20.04 AS system-packages
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -116,11 +116,6 @@ FROM system-packages AS base
 
 LABEL maintainer="lucas.bremond@gmail.com"
 
-# Aliases
-
-RUN alias ls='ls --color=auto' \
-   && alias ll='ls -halF'
-
 ## Clang-format & Clang
 
 ARG CLANG_VERSION="18"
@@ -136,7 +131,7 @@ RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-s
 
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && apt-get update \
-   && apt-get install -y gcc-13 g++-13 \
+   && apt-get install -y --no-install-recommends gcc-13 g++-13 \
    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \
    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130 \

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -93,6 +93,7 @@ RUN mkdir -p /tmp/boost \
    --with-stacktrace \
    --with-system \
    --with-thread \
+   --with-url \
    install \
    && rm -rf /tmp/boost
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -37,25 +37,12 @@ RUN apt-get update -y \
    ssh-client \
    && rm -rf /var/lib/apt/lists/*
 
-## Python installing dependencies
-
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y \
    && apt-get install -y --no-install-recommends \
    software-properties-common \
-   build-essential \
-   libncursesw5-dev \
-   libsqlite3-dev \
-   tk-dev \
-   libgdbm-dev \
-   libc6-dev \
-   libbz2-dev \
-   autotools-dev \
-   libicu-dev \
-   libffi-dev \
    zlib1g-dev \
-   gnupg \
    && rm -rf /var/lib/apt/lists/*
 
 ## Clang-format & Clang
@@ -80,34 +67,29 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \
    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130
 
-## Python
+## uv / Python
+COPY --from=ghcr.io/astral-sh/uv:0.9.21 /uv /uvx /bin/
 
-RUN add-apt-repository ppa:deadsnakes/ppa && \
-   apt-get update && apt-get install -y --no-install-recommends \
-   python3.9 python3.9-distutils python3.9-dev \
-   python3.10 python3.10-distutils python3.10-dev \
-   python3.11 python3.11-distutils python3.11-dev \
-   python3.12 python3.12-dev \
-   python3.13 python3.13-dev \
-   python3-dev \
-   && rm -rf /var/lib/apt/lists/*
+ARG OSTK_PYTHON_VERSION="3.11"
+ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"
 
-## Pip
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv-python"
+ENV UV_LINK_MODE="copy"
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 \
-   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
-   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 \
-   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
-   & curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13 \
-   & wait
+RUN uv python install 3.9 \ 
+   && uv python install 3.10 \ 
+   && uv python install 3.11 \ 
+   && uv python install 3.12 \ 
+   && uv python install 3.13 \
+   && chmod -R 777 ${UV_PYTHON_INSTALL_DIR} \
+   && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python \
+   && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python${OSTK_PYTHON_VERSION} \
+   && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python3
 
-## Python tools
-
-RUN python3.9 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.10 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.11 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.12 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen \
-   && python3.13 -m pip install --upgrade pip ipython setuptools build wheel twine pytest pybind11-stubgen
+# Create a venv for the default OSTk Python version. 
+ENV OSTK_VIRTUAL_ENV=/opt/ostk-venv
+RUN uv venv ${OSTK_VIRTUAL_ENV} --python ${OSTK_PYTHON_VERSION} \
+   && chmod -R 777 ${OSTK_VIRTUAL_ENV}
 
 ## CMake
 
@@ -191,13 +173,6 @@ RUN mkdir /tmp/openssl \
    && mv /usr/local/ssl/bin/c_rehash /usr/bin/c_rehash \
    && mv /usr/local/ssl/bin/openssl /usr/bin/openssl \
    && rm -rf /tmp/openssl
-
-## Black
-
-ARG OSTK_PYTHON_VERSION
-ENV OSTK_PYTHON_VERSION="3.11"
-
-RUN python${OSTK_PYTHON_VERSION} -m pip install black black[jupyter]
 
 # Environment
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -129,7 +129,9 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 130
 
 ## uv / Python
-COPY --from=ghcr.io/astral-sh/uv:0.9.21 /uv /uvx /bin/
+ARG UV_VERSION="0.10.6"
+
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
 
 ARG OSTK_PYTHON_VERSION="3.11"
 ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,18 +1,14 @@
 # Apache License 2.0
 
-FROM ubuntu:20.04 AS base
+# Common system packages
+FROM ubuntu:20.04 AS system-packages
 
-LABEL maintainer="lucas.bremond@gmail.com"
-
-# Aliases
-
-RUN alias ls='ls --color=auto' \
-   && alias ll='ls -halF'
-
-# Common Tools
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y \
    && apt-get install -y --no-install-recommends \
+   # Common utilities
+   ca-certificates \
    git \
    curl \
    wget \
@@ -20,30 +16,95 @@ RUN apt-get update -y \
    htop \
    tree \
    make \
-   libssl-dev \
-   && rm -rf /var/lib/apt/lists/*
-
-# Development Tools
-
-## GCC / GDB / lcov / doxygen
-
-RUN apt-get update -y \
-   && apt-get install -y --no-install-recommends \
+   tar \
+   perl \
+   # Development tools
    gcc \
    g++ \
    gdb \
    lcov \
    doxygen \
    ssh-client \
-   && rm -rf /var/lib/apt/lists/*
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -y \
-   && apt-get install -y --no-install-recommends \
+   # Build dependencies
    software-properties-common \
    zlib1g-dev \
+   libssl-dev \
    && rm -rf /var/lib/apt/lists/*
+
+# CMake builder
+FROM system-packages AS cmake-builder
+
+ARG TARGETPLATFORM
+ARG CMAKE_MAJOR_VERSION="3"
+ARG CMAKE_MINOR_VERSION="26"
+ARG CMAKE_PATCH_VERSION="3"
+ARG CMAKE_VERSION="${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}"
+
+RUN mkdir -p /tmp/cmake \
+   && mkdir -p /opt/cmake \
+   && cd /tmp/cmake \
+   && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+   && wget --quiet https://cmake.org/files/v${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/cmake-${CMAKE_VERSION}-linux-${PACKAGE_PLATFORM}.sh -O cmake-install.sh \
+   && chmod +x /tmp/cmake/cmake-install.sh \
+   && /tmp/cmake/cmake-install.sh --prefix=/opt/cmake --skip-license \
+   && rm -rf /tmp/cmake
+
+# GoogleTest builder
+FROM cmake-builder AS googletest-builder
+
+ARG GOOGLE_TEST_VERSION="1.12.0"
+
+RUN cd /tmp \
+   && git clone --branch release-${GOOGLE_TEST_VERSION} --depth 1 https://github.com/google/googletest.git \
+   && cd googletest \
+   && mkdir build \
+   && cd build \
+   && /opt/cmake/bin/cmake .. -DCMAKE_INSTALL_PREFIX=/opt/googletest \
+   && make -j $(nproc) \
+   && make install \
+   && rm -rf /tmp/googletest
+
+# Boost builder
+FROM system-packages AS boost-builder
+
+ARG BOOST_MAJOR_VERSION="1"
+ARG BOOST_MINOR_VERSION="87"
+ARG BOOST_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.0"
+
+RUN mkdir -p /tmp/boost \
+   && cd /tmp/boost \
+   && wget -O boost_${BOOST_VERSION}.tar.gz https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_0.tar.gz/download \
+   && tar -xf boost_${BOOST_VERSION}.tar.gz \
+   && cd boost_${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_0 \
+   && ./bootstrap.sh --prefix=/opt/boost \
+   && ./b2 -j $(nproc) link=shared cxxflags=-fPIC install \
+   && ./b2 -j $(nproc) link=static cxxflags=-fPIC install \
+   && rm -rf /tmp/boost
+
+# OpenSSL builder
+FROM system-packages AS openssl-builder
+
+ARG OPENSSL_VERSION="3.0.2"
+
+RUN mkdir -p /tmp/openssl \
+   && cd /tmp/openssl \
+   && wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+   && tar -xf openssl-${OPENSSL_VERSION}.tar.gz \
+   && cd openssl-${OPENSSL_VERSION} \
+   && ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib \
+   && make -j $(nproc) \
+   && make install \
+   && rm -rf /tmp/openssl
+
+# Main image
+FROM system-packages AS base
+
+LABEL maintainer="lucas.bremond@gmail.com"
+
+# Aliases
+
+RUN alias ls='ls --color=auto' \
+   && alias ll='ls -halF'
 
 ## Clang-format & Clang
 
@@ -93,86 +154,42 @@ RUN uv venv ${OSTK_VIRTUAL_ENV} --python ${OSTK_PYTHON_VERSION} \
 
 ## CMake
 
-ARG TARGETPLATFORM
-ARG CMAKE_MAJOR_VERSION="3"
-ARG CMAKE_MINOR_VERSION="26"
-ARG CMAKE_PATCH_VERSION="3"
-ARG CMAKE_VERSION="${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}"
-
-RUN mkdir -p /tmp/cmake \
-   && cd /tmp/cmake \
-   && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
-   && wget --quiet https://cmake.org/files/v${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/cmake-${CMAKE_VERSION}-linux-${PACKAGE_PLATFORM}.sh -O cmake-install.sh \
-   && chmod +x /tmp/cmake/cmake-install.sh \
-   && /tmp/cmake/cmake-install.sh --prefix=/usr/local --skip-license \
-   && rm -rf /tmp/cmake
+COPY --from=cmake-builder /opt/cmake/bin /usr/local/bin
+COPY --from=cmake-builder /opt/cmake/share /usr/local/share
 
 ## GoogleTest
 
-ARG GOOGLE_TEST_VERSION="1.12.0"
-
-RUN cd /tmp \
-   && git clone --branch release-${GOOGLE_TEST_VERSION} --depth 1 https://github.com/google/googletest.git \
-   && cd googletest \
-   && mkdir build \
-   && cd build \
-   && cmake .. \
-   && make -j $(nproc) \
-   && make install \
-   && rm -rf /tmp/googletest
-
-# Dependencies
+COPY --from=googletest-builder /opt/googletest /usr/local
 
 ## Pybind11
 
-ARG PYBIND_11_MAJOR_VERSION="2"
-ARG PYBIND_11_MINOR_VERSION="13"
-ARG PYBIND_11_PATCH_VERSION="6"
+ARG PYBIND11_VERSION="2.13.6"
 
-RUN mkdir /tmp/pybind11 \
+RUN mkdir -p /tmp/pybind11 \
    && cd /tmp/pybind11 \
-   && latest_version=$(wget -q -O - http://ftp.us.debian.org/debian/pool/main/p/pybind11/ | \
-   grep -o "pybind11-dev_${PYBIND_11_MAJOR_VERSION}\.${PYBIND_11_MINOR_VERSION}\.${PYBIND_11_PATCH_VERSION}-[0-9]\+_all\.deb" | \
-   sort -V | \
-   tail -n 1) \
-   && wget http://ftp.us.debian.org/debian/pool/main/p/pybind11/${latest_version} \
-   && apt-get install -y ./${latest_version} \
+   && wget https://github.com/pybind/pybind11/archive/refs/tags/v${PYBIND11_VERSION}.tar.gz \
+   && tar -xf v${PYBIND11_VERSION}.tar.gz \
+   && cd pybind11-${PYBIND11_VERSION} \
+   && mkdir build \
+   && cd build \
+   && cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DPYBIND11_TEST=OFF \
+   && make install \
    && rm -rf /tmp/pybind11
 
 ## Boost
 
-ARG BOOST_MAJOR_VERSION="1"
-ARG BOOST_MINOR_VERSION="87"
-ARG BOOST_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.0"
-
-RUN mkdir -p /tmp/boost \
-   && cd /tmp/boost \
-   && wget -O boost_${BOOST_VERSION}.tar.gz https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_0.tar.gz/download \
-   && tar -xf boost_${BOOST_VERSION}.tar.gz \
-   && cd boost_${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_0 \
-   && ./bootstrap.sh \
-   && ./b2 -j $(nproc) link=shared cxxflags=-fPIC install \
-   && ./b2 -j $(nproc) link=static cxxflags=-fPIC install \
-   && rm -rf /tmp/boost
+COPY --from=boost-builder /opt/boost/include /usr/local/include
+COPY --from=boost-builder /opt/boost/lib /usr/local/lib
 
 ## OpenSSL
 
-ARG OPENSSL_VERSION="3.0.2"
+COPY --from=openssl-builder /opt/openssl /usr/local/ssl
 
-RUN mkdir /tmp/openssl \
-   && cd /tmp/openssl \
-   && wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
-   && tar -xvf openssl-${OPENSSL_VERSION}.tar.gz \
-   && cd openssl-${OPENSSL_VERSION} \
-   && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib \
-   && make \
-   && make install \
-   && touch /etc/ld.so.conf.d/openssl-${OPENSSL_VERSION}.conf \
-   && echo "/usr/local/ssl/lib64" >> /etc/ld.so.conf.d/openssl-${OPENSSL_VERSION}.conf \
+RUN touch /etc/ld.so.conf.d/openssl.conf \
+   && echo "/usr/local/ssl/lib64" >> /etc/ld.so.conf.d/openssl.conf \
    && ldconfig \
    && mv /usr/local/ssl/bin/c_rehash /usr/bin/c_rehash \
-   && mv /usr/local/ssl/bin/openssl /usr/bin/openssl \
-   && rm -rf /tmp/openssl
+   && mv /usr/local/ssl/bin/openssl /usr/bin/openssl
 
 # Environment
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -151,10 +151,10 @@ ENV OSTK_PYTHON_VERSION="${OSTK_PYTHON_VERSION}"
 ENV UV_PYTHON_INSTALL_DIR="/opt/uv-python"
 ENV UV_LINK_MODE="copy"
 
-RUN uv python install 3.9 \ 
-   && uv python install 3.10 \ 
-   && uv python install 3.11 \ 
-   && uv python install 3.12 \ 
+RUN uv python install 3.9 \
+   && uv python install 3.10 \
+   && uv python install 3.11 \
+   && uv python install 3.12 \
    && uv python install 3.13 \
    && chmod -R 777 ${UV_PYTHON_INSTALL_DIR} \
    && ln -sf $(uv python find ${OSTK_PYTHON_VERSION}) /usr/local/bin/python \

--- a/tools/development/helpers/check-format-cpp.sh
+++ b/tools/development/helpers/check-format-cpp.sh
@@ -2,7 +2,7 @@
 
 # Apache License 2.0
 
-project_directory="$(git rev-parse --show-toplevel)"
+project_directory="/app"
 
 pushd "${project_directory}" > /dev/null
 

--- a/tools/development/helpers/check-format-cpp.sh
+++ b/tools/development/helpers/check-format-cpp.sh
@@ -6,7 +6,7 @@ project_directory="$(git rev-parse --show-toplevel)"
 
 pushd "${project_directory}" > /dev/null
 
-    clang-format -Werror --dry-run -style=file:thirdparty/clang/.clang-format $(find ~+ src/ include/ test/ bindings/python/src/ -name '*.cpp' -o -name '*.cxx' -o -name '*.hpp' -o -name '*.tpp') \
+    clang-format -Werror --dry-run -style=file:thirdparty/clang/.clang-format $(find src/ include/ test/ bindings/python/src/ -name '*.cpp' -o -name '*.cxx' -o -name '*.hpp' -o -name '*.tpp') \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/check-format-python.sh
+++ b/tools/development/helpers/check-format-python.sh
@@ -2,11 +2,9 @@
 
 # Apache License 2.0
 
-project_directory="$(git rev-parse --show-toplevel)"
+pushd "${PYTHON_WD}" > /dev/null
 
-pushd "${project_directory}" > /dev/null
-
-    "${OSTK_VIRTUAL_ENV}/bin/python" -m black --check --diff bindings/python/ \
+    uv run black --check --diff . \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/check-format-python.sh
+++ b/tools/development/helpers/check-format-python.sh
@@ -6,7 +6,7 @@ project_directory="$(git rev-parse --show-toplevel)"
 
 pushd "${project_directory}" > /dev/null
 
-    python${OSTK_PYTHON_VERSION} -m black --check --diff bindings/python/ \
+    "${OSTK_VIRTUAL_ENV}/bin/python" -m black --check --diff bindings/python/ \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/docs.sh
+++ b/tools/development/helpers/docs.sh
@@ -20,7 +20,11 @@ if [[ $1 == "--help" ]]; then
     exit 0
 fi
 
-VIRTUAL_ENV=${OSTK_VIRTUAL_ENV} uv pip install -r requirements.txt
+# Find and use the venv that was created when building the package.
+package_directory=(${project_directory}/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION})
+export VIRTUAL_ENV="${package_directory[0]}/.venv"
+
+uv pip install -r requirements.txt
 
 if [[ ! -z $1 ]] && [[ $1 == "--notebooks" ]]; then
     if [[ -z $2 ]]; then
@@ -43,8 +47,8 @@ if [[ ! -z $1 ]] && [[ $1 == "--notebooks" ]]; then
     cd ..
 fi
 
-"${OSTK_VIRTUAL_ENV}/bin/python" -m breathe.apidoc -o cpp_rst xml -g class
+uv run breathe-apidoc -o cpp_rst xml -g class
 
-"${OSTK_VIRTUAL_ENV}/bin/python" -m sphinx -j $(nproc) -b html . _build/html
+uv run sphinx-build -j $(nproc) -b html . _build/html
 
 popd > /dev/null

--- a/tools/development/helpers/docs.sh
+++ b/tools/development/helpers/docs.sh
@@ -2,7 +2,7 @@
 
 # Apache License 2.0
 
-project_directory="$(git rev-parse --show-toplevel)"
+project_directory="/app"
 docs_directory="${project_directory}/docs"
 
 pushd "${docs_directory}" > /dev/null

--- a/tools/development/helpers/docs.sh
+++ b/tools/development/helpers/docs.sh
@@ -20,7 +20,7 @@ if [[ $1 == "--help" ]]; then
     exit 0
 fi
 
-python${OSTK_PYTHON_VERSION} -m pip install -r requirements.txt
+VIRTUAL_ENV=${OSTK_VIRTUAL_ENV} uv pip install -r requirements.txt
 
 if [[ ! -z $1 ]] && [[ $1 == "--notebooks" ]]; then
     if [[ -z $2 ]]; then
@@ -43,8 +43,8 @@ if [[ ! -z $1 ]] && [[ $1 == "--notebooks" ]]; then
     cd ..
 fi
 
-breathe-apidoc -o cpp_rst xml -g class
+"${OSTK_VIRTUAL_ENV}/bin/python" -m breathe.apidoc -o cpp_rst xml -g class
 
-sphinx-build -j $(nproc) -b html . _build/html
+"${OSTK_VIRTUAL_ENV}/bin/python" -m sphinx -j $(nproc) -b html . _build/html
 
 popd > /dev/null

--- a/tools/development/helpers/format-cpp.sh
+++ b/tools/development/helpers/format-cpp.sh
@@ -5,8 +5,7 @@
 project_directory="$(git rev-parse --show-toplevel)"
 
 pushd "${project_directory}" > /dev/null
-
-    clang-format -i -style=file:thirdparty/clang/.clang-format $(find ~+ src/ include/ test/ bindings/python/src/ -name '*.cpp' -o -name '*.cxx' -o -name '*.hpp' -o -name '*.tpp') \
+    clang-format -i -style=file:thirdparty/clang/.clang-format $(find ~+/benchmark ~+/src/ ~+/include/ ~+/test/ ~+/bindings/python/src/ -name '*.cpp' -o -name '*.cxx' -o -name '*.hpp' -o -name '*.tpp') \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/format-python.sh
+++ b/tools/development/helpers/format-python.sh
@@ -2,11 +2,9 @@
 
 # Apache License 2.0
 
-project_directory="$(git rev-parse --show-toplevel)"
+pushd "${PYTHON_WD}" > /dev/null
 
-pushd "${project_directory}" > /dev/null
-
-    "${OSTK_VIRTUAL_ENV}/bin/python" -m black bindings/python/ \
+    uv run black . \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/format-python.sh
+++ b/tools/development/helpers/format-python.sh
@@ -6,7 +6,7 @@ project_directory="$(git rev-parse --show-toplevel)"
 
 pushd "${project_directory}" > /dev/null
 
-    python${OSTK_PYTHON_VERSION} -m black bindings/python/ \
+    "${OSTK_VIRTUAL_ENV}/bin/python" -m black bindings/python/ \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/install-python.sh
+++ b/tools/development/helpers/install-python.sh
@@ -12,7 +12,7 @@ export VIRTUAL_ENV=${OSTK_VIRTUAL_ENV}
 
 pushd ${python_directory} > /dev/null
 
-uv sync --all-extras --active
+uv pip install .
 
 popd > /dev/null
 

--- a/tools/development/helpers/install-python.sh
+++ b/tools/development/helpers/install-python.sh
@@ -7,12 +7,9 @@ py_version=$(echo "${OSTK_PYTHON_VERSION}" | sed 's/\.//')
 project_directory="$(git rev-parse --show-toplevel)"
 python_directory="${project_directory}/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}"
 
-# Use the "global" pre-created venv
-export VIRTUAL_ENV=${OSTK_VIRTUAL_ENV}
-
 pushd ${python_directory} > /dev/null
 
-uv pip install .
+uv sync --all-extras
 
 popd > /dev/null
 
@@ -24,6 +21,6 @@ do
 
     dep_underscore=$(echo ${dep} | tr '-' '_' | sed 's/\/$//')
 
-    uv pip install /usr/local/share/${dep_underscore}-*-py${py_version}-*.whl --quiet --force-reinstall;
+    uv pip install /usr/local/share/${dep_underscore}-*-cp${py_version}-*.whl --quiet --force-reinstall;
 
 done

--- a/tools/development/helpers/install-python.sh
+++ b/tools/development/helpers/install-python.sh
@@ -7,14 +7,16 @@ py_version=$(echo "${OSTK_PYTHON_VERSION}" | sed 's/\.//')
 project_directory="$(git rev-parse --show-toplevel)"
 python_directory="${project_directory}/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}"
 
+# Use the "global" pre-created venv
+export VIRTUAL_ENV=${OSTK_VIRTUAL_ENV}
+
 pushd ${python_directory} > /dev/null
 
-python${OSTK_PYTHON_VERSION} -m pip install plotly pandas
-python${OSTK_PYTHON_VERSION} -m pip install git+https://github.com/open-space-collective/cesiumpy
-python${OSTK_PYTHON_VERSION} -m pip install . --force-reinstall
+uv sync --all-extras --active
 
 popd > /dev/null
 
+# Used in OSTk's linked mode
 for dep in ${deps}
 do
 
@@ -22,6 +24,6 @@ do
 
     dep_underscore=$(echo ${dep} | tr '-' '_' | sed 's/\/$//')
 
-    python${OSTK_PYTHON_VERSION} -m pip install /usr/local/share/${dep_underscore}-*-py${py_version}-*.whl --quiet --force-reinstall;
+    uv pip install /usr/local/share/${dep_underscore}-*-py${py_version}-*.whl --quiet --force-reinstall;
 
 done

--- a/tools/development/helpers/install-python.sh
+++ b/tools/development/helpers/install-python.sh
@@ -10,6 +10,7 @@ python_directory="${project_directory}/build/bindings/python/OpenSpaceToolkit*Py
 pushd ${python_directory} > /dev/null
 
 uv sync --all-extras
+uv pip install "cesiumpy @ git+https://github.com/open-space-collective/cesiumpy@0.4.0" # TBR: after https://github.com/open-space-collective/open-space-toolkit/issues/183
 
 popd > /dev/null
 

--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -2,8 +2,7 @@
 
 # Apache License 2.0
 
-project_directory="$(git rev-parse --show-toplevel)"
-test_directory="${project_directory}/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}/ostk/*/test"
+test_directory="/app/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}/ostk/*/test"
 
 pushd ${test_directory} > /dev/null
 

--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -7,7 +7,7 @@ test_directory="${project_directory}/bindings/python/test"
 
 pushd "${test_directory}" > /dev/null
 
-    python${OSTK_PYTHON_VERSION} -m pytest -sv ${@} \
+    "${OSTK_VIRTUAL_ENV}/bin/python" -m pytest -sv ${@} \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -2,11 +2,11 @@
 
 # Apache License 2.0
 
-test_directory="/app/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}/ostk/*/test"
+test_directory="/app/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}"
 
 pushd ${test_directory} > /dev/null
 
-    uv run pytest -sv ${@} \
+    uv run pytest -sv test ${@} \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -3,11 +3,11 @@
 # Apache License 2.0
 
 project_directory="$(git rev-parse --show-toplevel)"
-test_directory="${project_directory}/bindings/python/test"
+test_directory="${project_directory}/build/bindings/python/OpenSpaceToolkit*Py-python-package-${OSTK_PYTHON_VERSION}/ostk/*/test"
 
-pushd "${test_directory}" > /dev/null
+pushd ${test_directory} > /dev/null
 
-    "${OSTK_VIRTUAL_ENV}/bin/python" -m pytest -sv ${@} \
+    uv run pytest -sv ${@} \
     || exit 1
 
 popd > /dev/null

--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -6,7 +6,7 @@ test_directory="/app/build/bindings/python/OpenSpaceToolkit*Py-python-package-${
 
 pushd ${test_directory} > /dev/null
 
-    uv run pytest -sv test ${@} \
+    uv run pytest -sv test "$@" \
     || exit 1
 
 popd > /dev/null


### PR DESCRIPTION
## Why this effort started
Ubuntu 20.04 [reached EOL](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) in May 2025, leading to [deadsnakes yanking its packages](https://github.com/deadsnakes/issues/issues/251#issuecomment-3357847914) and our [build pipelines for the base image](https://github.com/open-space-collective/open-space-toolkit/actions/runs/20775887109/job/60100279478) failing. Hence, we either had to update our Ubuntu version, or install Python through other means. 

Updating Ubuntu to 24.04 was ruled out due to incompatible breaking changes with `glibc` going from [2.31](https://launchpad.net/ubuntu/focal/+source/glibc) to [2.39](https://launchpad.net/ubuntu/noble/+source/glibc). Using a dedicated builder like [manylinux](https://github.com/pypa/manylinux) was considered out-of-scope for the moment. 

There was also other motivation to switch to a more modern Python toolchain, and hence, it was decided to use `uv` to manage our Python versions.

## Major changes
| Before | After | Why |
|--------|--------|--------|
| Python installed in the base image via `apt`, dependencies installed in system Pythons | Python installed & managed by `uv`. Dependencies installed in virtualenvs only. | [PEP 668](https://peps.python.org/pep-0668/) makes it much harder install into the system Python, even in containerized environments (though isn't applicable in Ubuntu 20.04); `uv` [strongly prefers](https://github.com/astral-sh/uv/issues/12204) the use of venvs, even in containerized environments. This is especially the case when we pre-install multiple Python versions. |
| Python dependencies defined in: base Docker image; helper shell scripts; downstream Makefiles; downstream `requirements.txt` | Python dependencies defined in: helper shell script (only `docs.sh`) and downstream `pyproject.toml`'s | Dependencies were defined all over the place and available globally. Now they are (mostly) well-defined in standard locations. 🚧 The docs dependencies could likely be incorporated into one of the `toml`'s too. |
| Python project setup split between `setup.cfg.in`, `pyproject.toml.in`, `requirements.txt`, `pyproject.toml` | Python project setup defined in `pyproject.toml` (for dev and CI), and `pyproject.toml.in` (for distribution) | Modernize project setup, and clarify responsibilities - `pyproject.toml` configures the project for dev and CI, i.e. does not require compiling any code, and can define linter/formatter settings. `pyproject.toml.in` defines build, test, and runtime dependencies, i.e. to be used during and after building the bindings. |
| In CI, code was checked out as a pipeline step and mounted into the dev image as a volume | In CI, code is baked into the images. Pipelines use this image as [container jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container), rather than having to check out the repo at each step. | CI images were not standalone environments (because they required the actual code to be mounted), making it much harder to debug issues and reproduce errors locally. Mounting the code also risked the venvs pre-baked in the image being overwritten. |

## Things that change in downstream OSTk repos as a result
The dev experience should largely remain the same, but how things are organised under-the-hood have been aligned and modernised. 
- The base Python directory is now explicitly `bindings/python/`. When the local development image is built, a `venv` will be created with all development dependencies (i.e. those _not required_ for building the bindings themselves)
- When the bindings are built, separate `venv`'s for each Python version will be created, and the built package will be installed into it. These live in `build/bindings/python/OpenSpaceToolkit*Py-python-package-<python-version>/`. These directories act as standalone Python-version-specific project directories, each with their own "hydrated" `pyproject.toml` (coming from the `pyproject.toml.in` template). These directories should be used for operations requiring the built bindings, such as running the Python unit tests and auto documentation generation.
- `*-standalone` Makefile targets, which were only used for CI, have been removed in favour of scripts that are executed from within the container. 
  - 🚧 Currently, this is a mix of the `ostk-*` common helper scripts hosted in this repo, along with Makefile targets (prefixed with `_`). Further effort should be made to align this, e.g. introduce an "inner" Makefile.
- the `CMakeLists` for the Python bindings has been updated to leverage `uv`
- Python unit tests are executed from where the bindings are built, not where they're installed.
  - i.e. note the removal of `test_python_directory` from the `Makefile`

## Other things that changed
- Made the base image multi-stage for heavy dependencies
- Fixed `check-format-cpp.sh` to not include the current dir, which was also picking up `build/` artifacts
- General attempts to reduce image size:
  - Only install the Boost modules we actually use
  - Only install `clang-format` instead of the entire toolchain
- Update Actions versions 

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI consistency by running builds, tests, formatting, and documentation generation inside a standardized development container.
  * Upgraded and streamlined GitHub Actions workflows for building, packaging, releasing, and benchmark reporting (including benchmark artifacts).
  * Refreshed the development Docker image with a more efficient multi-stage layout and updated Python/tooling setup.
  * Updated helper scripts for formatting, testing, and docs to align with the unified container/tooling workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->