### PR TITLE
ci: fix benchmark push

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "googlecpp"
-          output-file-path: ./cache/benchmark_result.json
+          output-file-path: /app/bin/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true # TBR
           alert-threshold: "200%"

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -66,7 +66,7 @@ jobs:
           tool: "googlecpp"
           output-file-path: benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true # TBR
+          auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "200%"
           comment-on-alert: true
 

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "googlecpp"
-          output-file-path: /app/bin/benchmark_result.json
+          output-file-path: benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true # TBR
           alert-threshold: "200%"

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -60,10 +60,9 @@ jobs:
       - uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "googlecpp"
-          output-file-path: benchmark_result.json
-          external-data-json-path: ./cache/benchmark-data.json
+          output-file-path: ./cache/benchmark_result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          auto-push: true # TBR
           alert-threshold: "200%"
           comment-on-alert: true
 

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -48,6 +48,10 @@ jobs:
     needs: benchmark-cpp
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout Repository # Required for github-action-benchmark
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Download benchmark result
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/open-space-collective/open-space-toolkit/pull/181

`external-data-json-path` actually disables pushing to the `gh-pages` branch; see https://github.com/open-space-collective/open-space-toolkit-astrodynamics/actions/runs/29416972634/job/87366740831

Example fixed ci [here](https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/695/checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved benchmark validation reliability by ensuring the full repository history is available before benchmarks run.
  * Benchmark results are now automatically published for every validation run (not limited to a specific branch), providing more consistent performance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->