### PR TITLE
ci: bump gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           merge-multiple: true
           path: packages/cpp/
       - name: Release C++ Package
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: packages/cpp/*


### PR DESCRIPTION
The major bumps are just to change the node runtime version, which should be safe. 

v1 targets a deprecated runtime
<img width="1314" height="83" alt="image" src="https://github.com/user-attachments/assets/44749fa7-4ece-48e6-a231-a1cba3953058" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release process to use the latest release publishing action.
  * Existing deployment steps and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->