### PR TITLE
chore: fix pytest args

### DIFF
--- a/tools/development/helpers/test-python.sh
+++ b/tools/development/helpers/test-python.sh
@@ -6,7 +6,7 @@ test_directory="/app/build/bindings/python/OpenSpaceToolkit*Py-python-package-${
 
 pushd ${test_directory} > /dev/null
 
-    uv run pytest -sv test "$@" \
+    uv run pytest -sv "$@" \
     || exit 1
 
 popd > /dev/null


### PR DESCRIPTION
so you can do `ostk-test-python test/my_test_file.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Python test helper to run the complete test suite with verbose output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->