### PR TITLE
ci: fix locale and doc generation

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8
+  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   benchmark-cpp:

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: en_US.UTF-8
+  LANG: C.UTF-8
 
 jobs:
   benchmark-cpp:

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   benchmark-cpp:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,7 +33,7 @@ env:
   DOCKER_REGISTRY_PATH: openspacecollective
   IMAGE_NAME: openspacecollective/${{ inputs.project_name }}-development
   IMAGE_TAG: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-  LANG: C.UTF-8
+  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   build-image-development:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,7 +33,6 @@ env:
   DOCKER_REGISTRY_PATH: openspacecollective
   IMAGE_NAME: openspacecollective/${{ inputs.project_name }}-development
   IMAGE_TAG: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   build-image-development:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,7 +33,7 @@ env:
   DOCKER_REGISTRY_PATH: openspacecollective
   IMAGE_NAME: openspacecollective/${{ inputs.project_name }}-development
   IMAGE_TAG: openspacecollective/${{ inputs.project_name }}-development:${{ inputs.project_version }}
-  LANG: en_US.UTF-8
+  LANG: C.UTF-8
 
 jobs:
   build-image-development:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   build-package-cpp:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: en_US.UTF-8
+  LANG: C.UTF-8
 
 jobs:
   build-package-cpp:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8
+  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   build-package-cpp:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   deploy-package-cpp:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: en_US.UTF-8
+  LANG: C.UTF-8
 
 jobs:
   deploy-package-cpp:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8
+  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   deploy-package-cpp:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: en_US.UTF-8
+  LANG: C.UTF-8
 
 jobs:
   format-check-cpp:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   format-check-cpp:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_REGISTRY_PATH: openspacecollective
-  LANG: C.UTF-8
+  LANG: C.UTF-8 # use the default locale available in the base image
 
 jobs:
   format-check-cpp:

--- a/tools/development/helpers/docs.sh
+++ b/tools/development/helpers/docs.sh
@@ -2,6 +2,8 @@
 
 # Apache License 2.0
 
+set -e
+
 project_directory="/app"
 docs_directory="${project_directory}/docs"
 


### PR DESCRIPTION
Doc generation was broken following https://github.com/open-space-collective/open-space-toolkit/pull/181 

- Now that we use [Container Jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container), the `LANG` env var that was declared in the CI files is actually injected into the container. Previously, steps executed `docker run`, providing an extra layer of "isolation". The `en_US.UTF-8` locale shouldn't be required, and isn't even available in the base image. 
- The docs build job was failing silently; let the script throw an error instead.

Before: https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/30101932004/job/89511146489#step:3:2045

After: https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/30820052235/job/91709014001?pr=210#step:3:2384

- Passing CI in `core`: https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/30822983642
- Passing CI in `astro`: https://github.com/open-space-collective/open-space-toolkit-astrodynamics/actions/runs/30824183781?pr=705
- Intentionally failing CI in `io` with new image but old CI to show now-failing build-docs: https://github.com/open-space-collective/open-space-toolkit-io/actions/runs/30824402472

